### PR TITLE
reside-61: Support scalable containers

### DIFF
--- a/constellation/__init__.py
+++ b/constellation/__init__.py
@@ -1,6 +1,7 @@
 from constellation.constellation import \
     Constellation, \
     ConstellationContainer, \
+    ConstellationService, \
     ConstellationMount
 from constellation.util import \
     ImageReference
@@ -8,6 +9,7 @@ from constellation.util import \
 __all__ = [
     Constellation,
     ConstellationContainer,
+    ConstellationService,
     ConstellationMount,
     ImageReference
 ]

--- a/constellation/constellation.py
+++ b/constellation/constellation.py
@@ -123,15 +123,7 @@ class ConstellationContainer:
         return container.status if container else "missing"
 
     def stop(self, prefix, kill=False):
-        container = self.get(prefix)
-        if container and container.status == "running":
-            action = "Killing" if kill else "Stop"
-            print("{} '{}'".format(action, self.name))
-            with docker_util.ignoring_missing():
-                if kill:
-                    container.kill()
-                else:
-                    container.stop()
+        docker_util.container_stop(self.get(prefix), kill, self.name)
 
     def remove(self, prefix):
         container = self.get(prefix)

--- a/constellation/docker_util.py
+++ b/constellation/docker_util.py
@@ -66,6 +66,17 @@ def remove_volume(name):
     v.remove(name)
 
 
+def container_stop(container, kill, name):
+    if container and container.status == "running":
+        action = "Killing" if kill else "Stop"
+        print("{} '{}'".format(action, name))
+        with ignoring_missing():
+            if kill:
+                container.kill()
+            else:
+                container.stop()
+
+
 def container_exists(name):
     return docker_exists("containers", name)
 

--- a/constellation/docker_util.py
+++ b/constellation/docker_util.py
@@ -188,6 +188,7 @@ def image_pull(name, ref):
     curr = client.images.pull(ref).short_id
     status = "unchanged" if prev == curr else "updated"
     print("    `-> {} ({})".format(curr, status))
+    return prev != curr
 
 
 def containers_matching(prefix, stopped):

--- a/constellation/docker_util.py
+++ b/constellation/docker_util.py
@@ -190,6 +190,12 @@ def image_pull(name, ref):
     print("    `-> {} ({})".format(curr, status))
 
 
+def containers_matching(prefix, stopped):
+    cl = docker.client.from_env()
+    return [x for x in cl.containers.list(stopped)
+            if x.name.startswith(prefix)]
+
+
 class ignoring_missing:
     def __init__(self):
         pass

--- a/constellation/util.py
+++ b/constellation/util.py
@@ -6,3 +6,13 @@ class ImageReference:
 
     def __str__(self):
         return "{}/{}:{}".format(self.repo, self.name, self.tag)
+
+
+def tabulate(x):
+    ret = {}
+    for el in x:
+        if el in ret.keys():
+            ret[el] += 1
+        else:
+            ret[el] = 1
+    return ret

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     "vault_dev"]
 
 setup(name="constellation",
-      version="0.0.3",
+      version="0.0.4",
       description="Deploy scripts for constellations of docker containers",
       long_description=long_description,
       classifiers=[

--- a/test/test_constellation.py
+++ b/test/test_constellation.py
@@ -306,13 +306,15 @@ def test_scalable_containers():
     s = f.getvalue()
     assert "client_{1-4}): missing,missing,missing,missing" in s
 
-    obj.start()
+    obj.start(pull_images=True)
 
-    cl = docker.client.from_env()
-    nms = [client.name_external(prefix, i + 1) for i in range(4)]
-    for nm in nms:
+    containers = client.get(prefix)
+
+    for i in range(4):
+        nm = client.name_external(prefix, i + 1)
         assert docker_util.container_exists(nm)
-        x = cl.containers.get(nm)
+        x = containers[i]
+        assert x.name == nm
         response = docker_util.exec_safely(x, ["curl", "http://server"])
         assert "Welcome to nginx" in response.output.decode("UTF-8")
 

--- a/test/test_docker_util.py
+++ b/test/test_docker_util.py
@@ -200,19 +200,21 @@ def test_pull_container():
 
     f = io.StringIO()
     with redirect_stdout(f):
-        image_pull("example", name)
+        res = image_pull("example", name)
 
     assert image_exists(name)
     assert "Pulling docker image example (hello-world:latest)" in f.getvalue()
     assert "updated" in f.getvalue()
+    assert res
 
     f = io.StringIO()
     with redirect_stdout(f):
-        image_pull("example", name)
+        res = image_pull("example", name)
 
     assert image_exists(name)
     assert "Pulling docker image example (hello-world:latest)" in f.getvalue()
     assert "unchanged" in f.getvalue()
+    assert not res
 
 
 def test_ignoring_missing_does_not_raise():

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -6,3 +6,10 @@ from constellation.util import *
 def test_image_reference_can_convert_to_string():
     ref = ImageReference("repo", "name", "tag")
     assert str(ref) == "repo/name:tag"
+
+
+def test_tabulate():
+    assert tabulate([]) == {}
+    assert tabulate(["a"]) == {"a": 1}
+    assert tabulate(["a", "a", "b"]) == {"a": 2, "b": 1}
+    assert tabulate(["a", "a", "b", "a"]) == {"a": 3, "b": 1}


### PR DESCRIPTION
This PR will add support for scalable containers - this will be used in `hint-deploy` to control hintr workers, but would be useful in the shiny deployment for the workers there too.

It is implemented using a new class `ConstellationService` that can be used in place of `ConstellationContainer` but which requires a `scale` argument during creation.

The number of replicate containers is used only during `start`.  All other interactions (`status`, `stop`, `remove`) will determine the containers that match the pattern.  This simplifies use - see the hintr-deploy for details where the subconfiguration is used only for start