### PR TITLE
reside-62: support for starting a subset of containers

### DIFF
--- a/constellation/__init__.py
+++ b/constellation/__init__.py
@@ -7,9 +7,9 @@ from constellation.util import \
     ImageReference
 
 __all__ = [
-    Constellation,
-    ConstellationContainer,
-    ConstellationService,
-    ConstellationMount,
-    ImageReference
+    "Constellation",
+    "ConstellationContainer",
+    "ConstellationService",
+    "ConstellationMount",
+    "ImageReference"
 ]

--- a/constellation/constellation.py
+++ b/constellation/constellation.py
@@ -196,7 +196,6 @@ class ConstellationContainerCollection:
                 return x
         raise Exception("Container '{}' not defined".format(name))
 
-
     def get(self, name, prefix, container=True):
         return self.find(name).get(prefix)
 

--- a/constellation/constellation.py
+++ b/constellation/constellation.py
@@ -65,6 +65,12 @@ class Constellation:
         if remove_volumes:
             self.volumes.remove()
 
+    def restart(self, pull_images=True):
+        if pull_images:
+            self.containers.pull_images()
+        self.stop()
+        self.start()
+
     def destroy(self):
         self.stop(True, True, True)
 

--- a/constellation/constellation.py
+++ b/constellation/constellation.py
@@ -3,7 +3,7 @@ import docker
 import constellation.docker_util as docker_util
 import constellation.vault as vault
 
-from constellation.util import tabulate
+from constellation.util import tabulate, rand_str
 
 
 class Constellation:
@@ -145,10 +145,6 @@ class ConstellationService():
         self.kwargs = kwargs
         self.base = ConstellationContainer(name, image, **kwargs)
 
-    def _container(self, i):
-        name = "{}_{}".format(self.name, i)
-        return ConstellationContainer(name, self.image, **self.kwargs)
-
     def name_external(self, prefix):
         return "{}_<i>".format(self.base.name_external(prefix))
 
@@ -160,8 +156,9 @@ class ConstellationService():
 
     def start(self, prefix, network, volumes, data=None):
         print("Starting *service* {}".format(self.name))
-        for i in range(1, self.scale + 1):
-            container = self._container(i)
+        for i in range(self.scale):
+            name = "{}_{}".format(self.name, rand_str(8))
+            container = ConstellationContainer(name, self.image, **self.kwargs)
             container.start(prefix, network, volumes, data)
 
     def get(self, prefix, stopped=False):

--- a/constellation/constellation.py
+++ b/constellation/constellation.py
@@ -190,11 +190,15 @@ class ConstellationContainerCollection:
     def __init__(self, collection):
         self.collection = collection
 
-    def get(self, name, prefix):
+    def find(self, name):
         for x in self.collection:
             if x.name == name:
-                return x.get(prefix)
+                return x
         raise Exception("Container '{}' not defined".format(name))
+
+
+    def get(self, name, prefix, container=True):
+        return self.find(name).get(prefix)
 
     def exists(self, prefix):
         return [x.exists(prefix) for x in self.collection]

--- a/constellation/docker_util.py
+++ b/constellation/docker_util.py
@@ -120,6 +120,23 @@ def container_wait_running(container, poll=0.1, timeout=1):
     return container
 
 
+def container_remove_wait(container, poll=0.1, timeout=1):
+    name = container.name
+    for i in range(math.ceil(timeout / poll)):
+        try:
+            container.remove()
+        except docker.errors.APIError:
+            pass
+        time.sleep(poll)
+
+    for i in range(math.ceil(timeout / poll)):
+        if not container_exists(name):
+            return
+        time.sleep(poll)
+
+    raise Exception("container '{}' was not removed in time".format(name))
+
+
 def simple_tar(path, name):
     f = tempfile.NamedTemporaryFile()
     t = tarfile.open(mode="w", fileobj=f)

--- a/constellation/util.py
+++ b/constellation/util.py
@@ -1,3 +1,7 @@
+import random
+import string
+
+
 class ImageReference:
     def __init__(self, repo, name, tag):
         self.repo = repo
@@ -16,3 +20,8 @@ def tabulate(x):
         else:
             ret[el] = 1
     return ret
+
+
+def rand_str(n, prefix=""):
+    s = "".join(random.choice(string.ascii_lowercase) for i in range(n))
+    return prefix + s

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     "vault_dev"]
 
 setup(name="constellation",
-      version="0.0.4",
+      version="0.0.5",
       description="Deploy scripts for constellations of docker containers",
       long_description=long_description,
       classifiers=[

--- a/test/test_constellation.py
+++ b/test/test_constellation.py
@@ -1,8 +1,6 @@
 import docker
 import io
 import pytest
-import random
-import string
 import vault_dev
 
 from contextlib import redirect_stdout
@@ -12,8 +10,7 @@ from constellation.util import ImageReference
 
 
 def rand_str(n=10, prefix="constellation_"):
-    s = "".join(random.choice(string.ascii_lowercase) for i in range(n))
-    return prefix + s
+    return constellation.util.rand_str(n, prefix)
 
 
 def test_container_ports_creates_ports_dictionary():

--- a/test/test_constellation.py
+++ b/test/test_constellation.py
@@ -5,8 +5,8 @@ import vault_dev
 
 from contextlib import redirect_stdout
 
+import constellation
 from constellation.constellation import *
-from constellation.util import ImageReference
 
 
 def rand_str(n=10, prefix="constellation_"):

--- a/test/test_docker_util.py
+++ b/test/test_docker_util.py
@@ -223,3 +223,14 @@ def test_ignoring_missing_does_not_raise():
             docker.client.from_env().containers.get("nosuchcontainer")
     except Exception:
         pytest.fail("Unexpected error")
+
+
+def test_container_remove_wait():
+    cl = docker.client.from_env()
+    container = cl.containers.run("alpine", ["sleep", "100"], detach=True)
+    with pytest.raises(Exception, match="was not removed in time"):
+        container_remove_wait(container, timeout=0.1)
+
+    container.kill()
+    container_remove_wait(container, timeout=10)
+    assert not container_exists(container.name)


### PR DESCRIPTION
This will be used in the hint deploy tool as a way of upgrading the hintr containers. There is also a new utility that is used to determine that a container has really vanished before we start trying to replace it