### PR TITLE
Reside 83: Resolve secrets before upgrade

### DIFF
--- a/constellation/constellation.py
+++ b/constellation/constellation.py
@@ -73,6 +73,7 @@ class Constellation:
 
     def resolve_secrets(self):
         if self.vault_config:
+            print("Resolving secrets")
             vault.resolve_secrets(self.data, self.vault_config.client())
 
     def destroy(self):

--- a/constellation/constellation.py
+++ b/constellation/constellation.py
@@ -48,8 +48,7 @@ class Constellation:
     def start(self, pull_images=False, subset=None):
         if subset is None and any(self.containers.exists(self.prefix)):
             raise Exception("Some containers exist")
-        if self.vault_config:
-            vault.resolve_secrets(self.data, self.vault_config.client())
+        self.resolve_secrets()
         if pull_images:
             self.containers.pull_images()
         self.network.create()
@@ -66,10 +65,15 @@ class Constellation:
             self.volumes.remove()
 
     def restart(self, pull_images=True):
+        self.resolve_secrets()
         if pull_images:
             self.containers.pull_images()
         self.stop()
         self.start()
+
+    def resolve_secrets(self):
+        if self.vault_config:
+            vault.resolve_secrets(self.data, self.vault_config.client())
 
     def destroy(self):
         self.stop(True, True, True)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     "vault_dev"]
 
 setup(name="constellation",
-      version="0.0.5",
+      version="0.0.6",
       description="Deploy scripts for constellations of docker containers",
       long_description=long_description,
       classifiers=[


### PR DESCRIPTION
This PR will resolve secrets earlier in an upgrade, which will prompt for the github token earlier (before images are pulled). By exposing the `resolve_secrets` method on the constellation object we can also call this when upgrading hintr alone (mrc-1146 - see separate PR in hint-deploy)