### PR TITLE
reside-101: allow port remapping

### DIFF
--- a/constellation/constellation.py
+++ b/constellation/constellation.py
@@ -76,6 +76,14 @@ class Constellation:
 
 
 class ConstellationContainer:
+    """For ports, to remap a port pass a tuple (port_container,
+    port_host), such as:
+
+    ports=[80, (2222, 3333)]
+
+    which will expose port 80 (same port on both the container and
+    host) and expose port 2222 in the container as 3333 on the host.
+    """
     def __init__(self, name, image, args=None,
                  mounts=None, ports=None, environment=None, configure=None):
         self.name = name
@@ -289,12 +297,13 @@ class ConstellationMount:
                                   **self.kwargs)
 
 
-# only handles the simple case of "expose a port" and not "remap a
-# port", and assumes the port is to be exposed onto all interfaces.
 def container_ports(ports):
     if not ports:
         return None
     ret = {}
     for p in ports:
-        ret["{}/tcp".format(p)] = p
+        if type(p) is int:
+            p = (p, p)
+        p_container, p_host = p
+        ret["{}/tcp".format(p_container)] = p_host
     return ret

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     "vault_dev"]
 
 setup(name="constellation",
-      version="0.0.5",
+      version="0.0.6",
       description="Deploy scripts for constellations of docker containers",
       long_description=long_description,
       classifiers=[

--- a/test/test_constellation.py
+++ b/test/test_constellation.py
@@ -19,6 +19,7 @@ def test_container_ports_creates_ports_dictionary():
     assert container_ports(None) is None
     assert container_ports([80]) == {"80/tcp": 80}
     assert container_ports([80, 443]) == {"80/tcp": 80, "443/tcp": 443}
+    assert container_ports([(5432, 15432)]) == {"5432/tcp": 15432}
 
 
 def test_network():


### PR DESCRIPTION
This PR allows remapping ports on export - it just wraps more of the Python API - see https://docker-py.readthedocs.io/en/stable/containers.html