### PR TITLE
mrc-3677: Add entrypoint arg to constellation container

### DIFF
--- a/constellation/constellation.py
+++ b/constellation/constellation.py
@@ -37,7 +37,7 @@ class Constellation:
         print("  * Volumes:")
         for v in self.volumes.collection:
             v_status = "created" if docker_util.volume_exists(v.name) \
-                    else "missing"
+                else "missing"
             print("    - {} ({}): {}".format(v.role, v.name, v_status))
         print("  * Containers:")
         for x in self.containers.collection:
@@ -84,8 +84,10 @@ class ConstellationContainer:
     which will expose port 80 (same port on both the container and
     host) and expose port 2222 in the container as 3333 on the host.
     """
+
     def __init__(self, name, image, args=None,
-                 mounts=None, ports=None, environment=None, configure=None):
+                 mounts=None, ports=None, environment=None, configure=None,
+                 entrypoint=None):
         self.name = name
         self.image = image
         self.args = args
@@ -93,6 +95,7 @@ class ConstellationContainer:
         self.ports = container_ports(ports)
         self.environment = environment
         self.configure = configure
+        self.entrypoint = entrypoint
 
     def name_external(self, prefix):
         return "{}_{}".format(prefix, self.name)
@@ -111,7 +114,8 @@ class ConstellationContainer:
         x = cl.containers.run(str(self.image), self.args, name=nm,
                               detach=True,
                               mounts=mounts, network="none", ports=self.ports,
-                              environment=self.environment)
+                              environment=self.environment,
+                              entrypoint=self.entrypoint)
         # There is a bit of a faff here, because I do not see how we
         # can get the container onto the network *and* alias it
         # without having 'create' put it on a network first.  This

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     "vault_dev"]
 
 setup(name="constellation",
-      version="0.0.10",
+      version="0.0.11",
       description="Deploy scripts for constellations of docker containers",
       long_description=long_description,
       classifiers=[

--- a/test/test_constellation.py
+++ b/test/test_constellation.py
@@ -394,3 +394,21 @@ def test_restart_pulls_and_replaces_containers():
     assert obj.containers.get("client", obj.prefix).id != id_client
 
     obj.destroy()
+
+
+def test_constellation_can_set_entrypoint():
+    """Bring up a container with entrypoint and verify that it works"""
+    name = "mything"
+    ref = ImageReference("library", "alpine", "latest")
+
+    container = ConstellationContainer(
+        "alpine", ref, entrypoint="echo", args="print this")
+
+    obj = Constellation(name, "prefix", [container], "network", None)
+    obj.start()
+
+    log = container.get("prefix").logs().decode("utf-8")
+
+    assert "print this\n" == log
+
+    obj.destroy()


### PR DESCRIPTION
We want this so we can the same image in orderly web deploy for orderly and the workers. We need to specify a different entrypoint for the workers.