### PR TITLE
Add arg to set working dir of a constellation container

### DIFF
--- a/constellation/constellation.py
+++ b/constellation/constellation.py
@@ -87,7 +87,7 @@ class ConstellationContainer:
 
     def __init__(self, name, image, args=None,
                  mounts=None, ports=None, environment=None, configure=None,
-                 entrypoint=None):
+                 entrypoint=None, working_dir=None):
         self.name = name
         self.image = image
         self.args = args
@@ -96,6 +96,7 @@ class ConstellationContainer:
         self.environment = environment
         self.configure = configure
         self.entrypoint = entrypoint
+        self.working_dir = working_dir
 
     def name_external(self, prefix):
         return "{}_{}".format(prefix, self.name)
@@ -115,7 +116,8 @@ class ConstellationContainer:
                               detach=True,
                               mounts=mounts, network="none", ports=self.ports,
                               environment=self.environment,
-                              entrypoint=self.entrypoint)
+                              entrypoint=self.entrypoint,
+                              working_dir=self.working_dir)
         # There is a bit of a faff here, because I do not see how we
         # can get the container onto the network *and* alias it
         # without having 'create' put it on a network first.  This

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     "vault_dev"]
 
 setup(name="constellation",
-      version="0.0.11",
+      version="0.0.12",
       description="Deploy scripts for constellations of docker containers",
       long_description=long_description,
       classifiers=[

--- a/test/test_constellation.py
+++ b/test/test_constellation.py
@@ -412,3 +412,26 @@ def test_constellation_can_set_entrypoint():
     assert "print this\n" == log
 
     obj.destroy()
+
+
+def test_constellation_can_set_working_dir():
+    """Bring up a container with working dir and verify that it works"""
+    name = "mything"
+    ref = ImageReference("library", "alpine", "latest")
+
+    container = ConstellationContainer(
+        "alpine", ref, entrypoint="ls")
+    container_dir = ConstellationContainer(
+        "alpine2", ref, entrypoint="ls", working_dir="/bin")
+
+    obj = Constellation(
+        name, "prefix", [container, container_dir], "network", None)
+    obj.start()
+
+    log = container.get("prefix").logs().decode("utf-8")
+    log_dir = container_dir.get("prefix").logs().decode("utf-8")
+
+    assert log != log_dir
+    assert "cat" in log_dir
+
+    obj.destroy()


### PR DESCRIPTION
In orderly web when we bring up the orderly and worker containers we want to set the working dir to be the dir of the mounted volume.