### PR TITLE
Add ability to set labels on docker container

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         # If installing a development version of constellation, use:
         # - pip3 install git+https://github.com/reside-ic/constellation@reside-62#egg=constellation
         run: |
-          python -m pip install --upgrade setuptools pip wheel
+          python -m pip install --upgrade setuptools pip urllib3==1.26.11 wheel
           python setup.py install --user
           pip3 install pytest-cov pycodestyle codecov
 

--- a/constellation/constellation.py
+++ b/constellation/constellation.py
@@ -87,7 +87,7 @@ class ConstellationContainer:
 
     def __init__(self, name, image, args=None,
                  mounts=None, ports=None, environment=None, configure=None,
-                 entrypoint=None, working_dir=None):
+                 entrypoint=None, working_dir=None, labels=None):
         self.name = name
         self.image = image
         self.args = args
@@ -97,6 +97,7 @@ class ConstellationContainer:
         self.configure = configure
         self.entrypoint = entrypoint
         self.working_dir = working_dir
+        self.labels = labels
 
     def name_external(self, prefix):
         return "{}_{}".format(prefix, self.name)
@@ -117,7 +118,8 @@ class ConstellationContainer:
                               mounts=mounts, network="none", ports=self.ports,
                               environment=self.environment,
                               entrypoint=self.entrypoint,
-                              working_dir=self.working_dir)
+                              working_dir=self.working_dir,
+                              labels=self.labels)
         # There is a bit of a faff here, because I do not see how we
         # can get the container onto the network *and* alias it
         # without having 'create' put it on a network first.  This

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     "vault_dev"]
 
 setup(name="constellation",
-      version="0.0.12",
+      version="0.0.13",
       description="Deploy scripts for constellations of docker containers",
       long_description=long_description,
       classifiers=[

--- a/test/test_constellation.py
+++ b/test/test_constellation.py
@@ -435,3 +435,24 @@ def test_constellation_can_set_working_dir():
     assert "cat" in log_dir
 
     obj.destroy()
+
+
+def test_constellation_can_set_labels():
+    """Bring up a container with labels and verify that it works"""
+    name = "mything"
+    ref = ImageReference("library", "alpine", "latest")
+
+    labels = {"label1": "value1", "label2": "value2"}
+    container = ConstellationContainer(
+        "alpine", ref, entrypoint="ls")
+    container_label = ConstellationContainer(
+        "alpine2", ref, entrypoint="ls", labels=labels)
+
+    obj = Constellation(
+        name, "prefix", [container, container_label], "network", None)
+    obj.start()
+
+    assert container.get("prefix").labels == {}
+    assert container_label.get("prefix").labels == labels
+
+    obj.destroy()


### PR DESCRIPTION
This PR will add support for setting labels on docker container. This passes arg straight through to python docker SDK https://docker-py.readthedocs.io/en/stable/containers.html

We want this because to ship logs to ELK we are using filebeat with autodiscover https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html this uses labels on docker container to control how logs are written back.