### PR TITLE
mrc-4273 replace underscores with hyphens in container names

### DIFF
--- a/constellation/constellation.py
+++ b/constellation/constellation.py
@@ -168,7 +168,7 @@ class ConstellationService():
         self.base = ConstellationContainer(name, image, **kwargs)
 
     def name_external(self, prefix):
-        return "{}_<i>".format(self.base.name_external(prefix))
+        return "{}-<i>".format(self.base.name_external(prefix))
 
     def pull_image(self):
         self.base.pull_image()
@@ -184,7 +184,7 @@ class ConstellationService():
             container.start(prefix, network, volumes, data)
 
     def get(self, prefix, stopped=False):
-        pattern = self.base.name_external(prefix) + "_"
+        pattern = self.base.name_external(prefix) + "-"
         return docker_util.containers_matching(pattern, stopped)
 
     def status(self, prefix):

--- a/constellation/constellation.py
+++ b/constellation/constellation.py
@@ -100,7 +100,7 @@ class ConstellationContainer:
         self.labels = labels
 
     def name_external(self, prefix):
-        return "{}_{}".format(prefix, self.name)
+        return "{}-{}".format(prefix, self.name)
 
     def pull_image(self):
         docker_util.image_pull(self.name, str(self.image))
@@ -179,7 +179,7 @@ class ConstellationService():
     def start(self, prefix, network, volumes, data=None):
         print("Starting *service* {}".format(self.name))
         for i in range(self.scale):
-            name = "{}_{}".format(self.name, rand_str(8))
+            name = "{}-{}".format(self.name, rand_str(8))
             container = ConstellationContainer(name, self.image, **self.kwargs)
             container.start(prefix, network, volumes, data)
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     "vault_dev"]
 
 setup(name="constellation",
-      version="0.0.13",
+      version="1.0.0",
       description="Deploy scripts for constellations of docker containers",
       long_description=long_description,
       classifiers=[

--- a/test/test_constellation.py
+++ b/test/test_constellation.py
@@ -10,7 +10,7 @@ from constellation.constellation import *
 from constellation.util import ImageReference
 
 
-def rand_str(n=10, prefix="constellation_"):
+def rand_str(n=10, prefix="constellation-"):
     return constellation.util.rand_str(n, prefix)
 
 
@@ -302,7 +302,8 @@ def test_scalable_containers():
     with redirect_stdout(f):
         obj.status()
 
-    assert "client_<i>): missing" in f.getvalue()
+    print(f.getvalue())
+    assert "client-<i>): missing" in f.getvalue()
 
     obj.start(pull_images=True)
 
@@ -310,13 +311,13 @@ def test_scalable_containers():
     with redirect_stdout(f):
         obj.status()
 
-    assert "client_<i>): running (4)" in f.getvalue()
+    assert "client-<i>): running (4)" in f.getvalue()
 
     containers = client.get(prefix)
 
     for i in range(4):
         x = containers[i]
-        assert x.name.startswith("{}-client_".format(prefix))
+        assert x.name.startswith("{}-client-".format(prefix))
         response = docker_util.exec_safely(x, ["curl", "http://server"])
         assert "Welcome to nginx" in response.output.decode("UTF-8")
 

--- a/test/test_constellation.py
+++ b/test/test_constellation.py
@@ -106,7 +106,7 @@ def test_mount_with_args():
 def test_container_simple():
     nm = rand_str(prefix="")
     x = ConstellationContainer(nm, "library/redis:5.0")
-    assert x.name_external("prefix") == "prefix_{}".format(nm)
+    assert x.name_external("prefix") == "prefix-{}".format(nm)
     assert not x.exists("prefix")
     assert x.get("prefix") is None
     f = io.StringIO()
@@ -179,7 +179,7 @@ def test_container_collection():
     obj.start(prefix, nw, [])
 
     cl = obj.get("client", prefix)
-    assert cl.name == "{}_client".format(prefix)
+    assert cl.name == "{}-client".format(prefix)
     assert obj.exists(prefix) == [True, True]
     obj.stop(prefix)
     obj.remove(prefix)
@@ -214,7 +214,7 @@ def test_constellation():
 
     assert "Network:\n    - thenw: missing" in p
     assert "Volumes:\n    - data (mydata): missing" in p
-    assert "Containers:\n    - server ({}_server): missing".format(prefix) in p
+    assert "Containers:\n    - server ({}-server): missing".format(prefix) in p
 
     obj.start(True)
 
@@ -226,7 +226,7 @@ def test_constellation():
 
     assert "Network:\n    - thenw: created" in p
     assert "Volumes:\n    - data (mydata): created" in p
-    assert "Containers:\n    - server ({}_server): running".format(prefix) in p
+    assert "Containers:\n    - server ({}-server): running".format(prefix) in p
 
     x = obj.containers.get("client", prefix)
     response = docker_util.exec_safely(x, ["curl", "http://server"])
@@ -316,7 +316,7 @@ def test_scalable_containers():
 
     for i in range(4):
         x = containers[i]
-        assert x.name.startswith("{}_client_".format(prefix))
+        assert x.name.startswith("{}-client_".format(prefix))
         response = docker_util.exec_safely(x, ["curl", "http://server"])
         assert "Welcome to nginx" in response.output.decode("UTF-8")
 


### PR DESCRIPTION
Hostnames must not contain underscores: https://en.wikipedia.org/wiki/Hostname#Syntax This is enforced by some services, e.g. Tomcat, which we are using in our Java applications. This PR changes the joining characeter between the constellation prefix and the container name from an underscore to a hyphen. 