### PR TITLE
recursive fix for objects as well

### DIFF
--- a/constellation/vault.py
+++ b/constellation/vault.py
@@ -37,6 +37,8 @@ def resolve_secrets_object(obj, client):
             updated, v = resolve_secret(v, client)
             if updated:
                 setattr(obj, k, v)
+        if type(v) == dict:
+            resolve_secrets_dict(v, client)
 
 
 def resolve_secrets_dict(d, client):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     "vault_dev"]
 
 setup(name="constellation",
-      version="1.1.1",
+      version="1.1.2",
       description="Deploy scripts for constellations of docker containers",
       long_description=long_description,
       classifiers=[

--- a/test/test_vault.py
+++ b/test/test_vault.py
@@ -36,9 +36,9 @@ def test_secret_reading_of_dicts_recursive():
         client = s.client()
         client.write("secret/foo", value="s3cret")
         # With data
-        dat = {"foo": {"bar": "VAULT:secret/foo:value"}}
+        dat = {"foo": {"bar": {"fizz": "VAULT:secret/foo:value"}}}
         resolve_secrets(dat, client)
-        assert dat == {"foo": {"bar": "s3cret"}}
+        assert dat == {"foo": {"bar": {"fizz": "s3cret"}}}
         # Without
         empty = {}
         resolve_secrets(empty, client)
@@ -54,11 +54,13 @@ def test_secret_reading_of_objects():
             def __init__(self):
                 self.foo = "VAULT:secret/foo:value"
                 self.bar = "constant"
+                self.fizz = {"secret": "VAULT:secret/foo:value"}
 
         dat = Data()
         resolve_secrets(dat, client)
         assert dat.foo == "s3cret"
         assert dat.bar == "constant"
+        assert dat.fizz == {"secret": "s3cret"}
 
 
 def test_accessor_validation():


### PR DESCRIPTION
My previous fix didn't work for configs that are named classes :facepalm: This sorts it and is confirmed working with `montagu-deploy`!