### PR TITLE
Network alias on creation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VAULT_TEST_GITHUB_PAT: ${{ secrets.VAULT_TEST_GITHUB_PAT }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@v2
 
@@ -41,4 +42,4 @@ jobs:
           pycodestyle . --exclude=.eggs
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Tests
         run: |
-          pytest --cov=src
+          pytest --cov=constellation
 
       - name: Lint
         run: |

--- a/constellation/constellation.py
+++ b/constellation/constellation.py
@@ -117,20 +117,27 @@ class ConstellationContainer:
         nm = self.name_external(prefix)
         print("Starting {} ({})".format(self.name, str(self.image)))
         mounts = [x.to_mount(volumes) for x in self.mounts]
+
         if self.ports_config:
             # don't have to specify TCP vs UDP here because TCP is the default
-            host_config = cl.api.create_host_config(mounts=mounts, port_bindings=self.ports_config)
+            host_config = cl.api.create_host_config(
+                mounts=mounts,
+                port_bindings=self.ports_config
+            )
         else:
             host_config = cl.api.create_host_config(mounts=mounts)
+
+        endpoint_config = cl.api.create_endpoint_config(aliases=[self.name])
         networking_config = cl.api.create_networking_config({
-            f"{network.name or self.network}": cl.api.create_endpoint_config(aliases=[self.name])
+            f"{network.name}": endpoint_config
         })
         x_obj = cl.api.create_container(str(self.image), self.args, name=nm,
-                                        detach=True, ports=self.container_ports,
+                                        detach=True, labels=self.labels,
+                                        ports=self.container_ports,
                                         environment=self.environment,
                                         entrypoint=self.entrypoint,
                                         working_dir=self.working_dir,
-                                        labels=self.labels, host_config=host_config,
+                                        host_config=host_config,
                                         networking_config=networking_config)
         container_id = x_obj["Id"]
         x = cl.containers.get(container_id)

--- a/test/test_constellation.py
+++ b/test/test_constellation.py
@@ -174,7 +174,8 @@ def test_container_ports():
         nw = ConstellationNetwork(rand_str())
         nw.create()
         x.start("prefix", nw, None)
-        port_bindings = cl.api.inspect_container(f"prefix-{nm}")["HostConfig"]["PortBindings"]
+        container_config = cl.api.inspect_container(f"prefix-{nm}")
+        port_bindings = container_config["HostConfig"]["PortBindings"]
         assert port_bindings == {
             "80/tcp": [{"HostIp": "", "HostPort": "80"}],
             "3000/tcp": [{"HostIp": "", "HostPort": "8080"}],

--- a/test/test_constellation.py
+++ b/test/test_constellation.py
@@ -14,12 +14,18 @@ def rand_str(n=10, prefix="constellation-"):
     return constellation.util.rand_str(n, prefix)
 
 
-def test_container_ports_creates_ports_dictionary():
-    assert container_ports([]) is None
+def test_ports_create_port_config_and_container_ports():
+    assert port_config([]) is None
+    assert port_config(None) is None
+    assert port_config([80]) == {80: 80}
+    assert port_config([80, 443]) == {80: 80, 443: 443}
+    assert port_config([(5432, 15432)]) == {5432: 15432}
+    assert port_config([(5432, 15432), 1]) == {5432: 15432, 1: 1}
+
     assert container_ports(None) is None
-    assert container_ports([80]) == {"80/tcp": 80}
-    assert container_ports([80, 443]) == {"80/tcp": 80, "443/tcp": 443}
-    assert container_ports([(5432, 15432)]) == {"5432/tcp": 15432}
+    assert container_ports({80: 80}) == [80]
+    assert container_ports({80: 80, 443: 443}) == [80, 443]
+    assert container_ports({1: 2, 3: 4, 5: 5}) == [1, 3, 5]
 
 
 def test_network():

--- a/test/test_constellation.py
+++ b/test/test_constellation.py
@@ -164,6 +164,26 @@ def test_container_start_configure():
         nw.remove()
 
 
+def test_container_ports():
+    try:
+        nm = rand_str(prefix="")
+        cl = docker.client.from_env()
+        cl.images.pull("library/alpine:latest")
+        x = ConstellationContainer(nm, "library/alpine:latest",
+                                   ports=[80, (3000, 8080)])
+        nw = ConstellationNetwork(rand_str())
+        nw.create()
+        x.start("prefix", nw, None)
+        port_bindings = cl.api.inspect_container(f"prefix-{nm}")["HostConfig"]["PortBindings"]
+        assert port_bindings == {
+            "80/tcp": [{"HostIp": "", "HostPort": "80"}],
+            "3000/tcp": [{"HostIp": "", "HostPort": "8080"}],
+        }
+    finally:
+        x.stop("prefix", True)
+        nw.remove()
+
+
 def test_container_pull():
     ref = "library/hello-world:latest"
     x = ConstellationContainer("hello", ref)


### PR DESCRIPTION
This is needed for wodin deploy as wodin containers immediately look for the redis container upon start up and the old way of aliasing a container on a network in constellation was:
* create container on "none" network
* disconnect container from that network
* reconnect container with alias on the actual network

This meant that sometimes wodin containers would not find redis and would stop running. Here we alias onto the network on creation which solves wodin deploy issues.

I have also added codecov back into constellation in this PR. The codecov is failing only because of the vault tests that we skipped in the add-preconfigure branch.