### PR TITLE
Allow bind mounts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ exclude_lines = [
   "no cov",
   "if __name__ == .__main__.:",
   "if TYPE_CHECKING:",
+  "raise NotImplementedError",
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,6 @@ exclude_lines = [
   "no cov",
   "if __name__ == .__main__.:",
   "if TYPE_CHECKING:",
-  "raise NotImplementedError",
 ]
 
 [tool.black]

--- a/src/constellation/__about__.py
+++ b/src/constellation/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Rich FitzJohn <r.fitzjohn@imperial.ac.uk>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/src/constellation/__init__.py
+++ b/src/constellation/__init__.py
@@ -1,15 +1,17 @@
 from constellation.constellation import (
     Constellation,
+    ConstellationBindMount,
     ConstellationContainer,
     ConstellationService,
-    ConstellationMount,
+    ConstellationVolumeMount,
 )
 from constellation.util import ImageReference
 
 __all__ = [
     "Constellation",
+    "ConstellationBindMount",
     "ConstellationContainer",
     "ConstellationService",
-    "ConstellationMount",
+    "ConstellationVolumeMount",
     "ImageReference",
 ]

--- a/src/constellation/constellation.py
+++ b/src/constellation/constellation.py
@@ -353,8 +353,6 @@ class ConstellationVolumeMount(_ConstellationMount):
         self.kwargs["type"] = "volume"
 
     def to_mount(self, volumes):
-        if volumes is None:
-            raise ValueError("`volumes` must be provided for VolumeMount")
         return docker.types.Mount(
             self.target, volumes.get(self.name), **self.kwargs
         )

--- a/src/constellation/constellation.py
+++ b/src/constellation/constellation.py
@@ -117,7 +117,7 @@ class ConstellationContainer:
         name,
         image,
         args=None,
-        mounts: list[_ConstellationMount] = [],
+        mounts=None,
         ports=None,
         environment=None,
         configure=None,
@@ -130,7 +130,7 @@ class ConstellationContainer:
         self.name = name
         self.image = image
         self.args = args
-        self.mounts = mounts
+        self.mounts = mounts or []
         self.ports_config = port_config(ports)
         self.container_ports = container_ports(self.ports_config)
         self.environment = environment
@@ -150,7 +150,7 @@ class ConstellationContainer:
     def exists(self, prefix):
         return docker_util.container_exists(self.name_external(prefix))
 
-    def start(self, prefix, network, volumes: dict, data=None):
+    def start(self, prefix, network, volumes, data=None):
         cl = docker.client.from_env()
         nm = self.name_external(prefix)
         print("Starting {} ({})".format(self.name, str(self.image)))

--- a/src/constellation/constellation.py
+++ b/src/constellation/constellation.py
@@ -335,15 +335,27 @@ class ConstellationNetwork:
         docker_util.remove_network(self.name)
 
 
-class ConstellationMount:
-    def __init__(self, name, path, **kwargs):
+class ConstellationVolumeMount:
+    def __init__(self, name, target, **kwargs):
         self.name = name
-        self.path = path
-        self.kwargs = kwargs
+        self.target = target
+        self.kwargs = {**kwargs, "type": "volume"}
 
     def to_mount(self, volumes):
         return docker.types.Mount(
-            self.path, volumes.get(self.name), **self.kwargs
+            self.target, volumes.get(self.name), **self.kwargs
+        )
+
+
+class ConstellationBindMount:
+    def __init__(self, source, target, **kwargs):
+        self.source = source
+        self.target = target
+        self.kwargs = {**kwargs, "type": "bind"}
+
+    def to_mount(self, _volumes=None):
+        return docker.types.Mount(
+            self.target, self.source, **self.kwargs
         )
 
 

--- a/src/constellation/constellation.py
+++ b/src/constellation/constellation.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Protocol, Optional
+from typing import Optional
 import docker
 
 import constellation.docker_util as docker_util

--- a/src/constellation/constellation.py
+++ b/src/constellation/constellation.py
@@ -113,7 +113,7 @@ class ConstellationContainer:
         name,
         image,
         args=None,
-        mounts: list[_ConstellationMount]=[],
+        mounts: list[_ConstellationMount] = [],
         ports=None,
         environment=None,
         configure=None,
@@ -368,9 +368,7 @@ class ConstellationBindMount:
         self.kwargs["type"] = "bind"
 
     def to_mount(self, _volumes):
-        return docker.types.Mount(
-            self.target, self.source, **self.kwargs
-        )
+        return docker.types.Mount(self.target, self.source, **self.kwargs)
 
 
 def int_into_tuple(i):

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -81,31 +81,61 @@ def test_empty_volume_collection():
 
 
 # This one needs the volume collection to test
-def test_mount_with_no_args():
-    role1 = "role1"
-    role2 = "role2"
-    name1 = rand_str()
-    name2 = rand_str()
-    vols = ConstellationVolumeCollection({role1: name1, role2: name2})
-    m = ConstellationMount(role1, "path")
-    assert m.name == "role1"
-    assert m.path == "path"
-    assert m.kwargs == {}
-    assert m.to_mount(vols) == docker.types.Mount("path", name1)
-
-
-def test_mount_with_args():
+def test_volume_mount_with_no_args():
     role1 = "role1"
     role2 = "role2"
     name1 = rand_str()
     name2 = rand_str()
     vols = ConstellationVolumeCollection({role1: name1, role2: name2})
 
-    m = ConstellationMount("role1", "path", read_only=True)
+    m = ConstellationVolumeMount(role1, "target_path")
     assert m.name == "role1"
-    assert m.path == "path"
-    assert m.kwargs == {"read_only": True}
-    assert m.to_mount(vols) == docker.types.Mount("path", name1, read_only=True)
+    assert m.target == "target_path"
+    assert m.kwargs == {"type": "volume"}
+    assert m.to_mount(vols) == docker.types.Mount("target_path", name1, type="volume")
+
+
+def test_volume_mount_with_args():
+    role1 = "role1"
+    role2 = "role2"
+    name1 = rand_str()
+    name2 = rand_str()
+    vols = ConstellationVolumeCollection({role1: name1, role2: name2})
+
+    m = ConstellationVolumeMount("role1", "target_path", read_only=True)
+    assert m.name == "role1"
+    assert m.target == "target_path"
+    assert m.kwargs == {"type": "volume", "read_only": True}
+    assert m.to_mount(vols) == docker.types.Mount("target_path", name1, type="volume", read_only=True)
+
+
+def test_bind_mount_with_no_args():
+    role1 = "role1"
+    role2 = "role2"
+    name1 = rand_str()
+    name2 = rand_str()
+    # Creat volume collection so that we can test the interface of to_mount
+    vols = ConstellationVolumeCollection({role1: name1, role2: name2})
+
+    m = ConstellationBindMount("source_path", "target_path")
+    assert m.source == "source_path"
+    assert m.target == "target_path"
+    assert m.kwargs == {"type": "bind"}
+    assert m.to_mount(vols) == docker.types.Mount("target_path", "source_path", type="bind")
+
+
+def test_bind_mount_with_args():
+    role1 = "role1"
+    role2 = "role2"
+    name1 = rand_str()
+    name2 = rand_str()
+    vols = ConstellationVolumeCollection({role1: name1, role2: name2})
+
+    m = ConstellationBindMount("source_path", "target_path", read_only=True)
+    assert m.source == "source_path"
+    assert m.target == "target_path"
+    assert m.kwargs == {"type": "bind", "read_only": True}
+    assert m.to_mount(vols) == docker.types.Mount("target_path", "source_path", type="bind", read_only=True)
 
 
 def test_container_simple():

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -80,6 +80,13 @@ def test_empty_volume_collection():
         pytest.fail("Unexpected error")
 
 
+def test_volume_mount_with_relative_paths():
+    with pytest.raises(
+        ValueError, match="Path 'target_path' must be an absolute path."
+    ):
+        ConstellationVolumeMount("role1", "target_path")
+
+
 # This one needs the volume collection to test
 def test_volume_mount_with_no_args():
     role1 = "role1"
@@ -88,12 +95,13 @@ def test_volume_mount_with_no_args():
     name2 = rand_str()
     vols = ConstellationVolumeCollection({role1: name1, role2: name2})
 
-    m = ConstellationVolumeMount(role1, "target_path")
+    absolute_target_path = "/target_path"
+    m = ConstellationVolumeMount(role1, absolute_target_path)
     assert m.name == "role1"
-    assert m.target == "target_path"
+    assert m.target == absolute_target_path
     assert m.kwargs == {"type": "volume"}
     assert m.to_mount(vols) == docker.types.Mount(
-        "target_path", name1, type="volume"
+        absolute_target_path, name1, type="volume"
     )
 
 
@@ -104,13 +112,25 @@ def test_volume_mount_with_args():
     name2 = rand_str()
     vols = ConstellationVolumeCollection({role1: name1, role2: name2})
 
-    m = ConstellationVolumeMount("role1", "target_path", read_only=True)
+    absolute_target_path = "/target_path"
+    m = ConstellationVolumeMount("role1", absolute_target_path, read_only=True)
     assert m.name == "role1"
-    assert m.target == "target_path"
+    assert m.target == absolute_target_path
     assert m.kwargs == {"type": "volume", "read_only": True}
     assert m.to_mount(vols) == docker.types.Mount(
-        "target_path", name1, type="volume", read_only=True
+        absolute_target_path, name1, type="volume", read_only=True
     )
+
+
+def test_volume_mount_with_relative_paths():
+    with pytest.raises(
+        ValueError, match="Path 'target_path' must be an absolute path."
+    ):
+        ConstellationBindMount("/source_path", "target_path")
+    with pytest.raises(
+        ValueError, match="Path 'source_path' must be an absolute path."
+    ):
+        ConstellationBindMount("source_path", "/target_path")
 
 
 def test_bind_mount_with_no_args():
@@ -121,12 +141,12 @@ def test_bind_mount_with_no_args():
     # Creat volume collection so that we can test the interface of to_mount
     vols = ConstellationVolumeCollection({role1: name1, role2: name2})
 
-    m = ConstellationBindMount("source_path", "target_path")
-    assert m.source == "source_path"
-    assert m.target == "target_path"
+    m = ConstellationBindMount("/source_path", "/target_path")
+    assert m.source == "/source_path"
+    assert m.target == "/target_path"
     assert m.kwargs == {"type": "bind"}
     assert m.to_mount(vols) == docker.types.Mount(
-        "target_path", "source_path", type="bind"
+        "/target_path", "/source_path", type="bind"
     )
 
 
@@ -137,12 +157,12 @@ def test_bind_mount_with_args():
     name2 = rand_str()
     vols = ConstellationVolumeCollection({role1: name1, role2: name2})
 
-    m = ConstellationBindMount("source_path", "target_path", read_only=True)
-    assert m.source == "source_path"
-    assert m.target == "target_path"
+    m = ConstellationBindMount("/source_path", "/target_path", read_only=True)
+    assert m.source == "/source_path"
+    assert m.target == "/target_path"
     assert m.kwargs == {"type": "bind", "read_only": True}
     assert m.to_mount(vols) == docker.types.Mount(
-        "target_path", "source_path", type="bind", read_only=True
+        "/target_path", "/source_path", type="bind", read_only=True
     )
 
 

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -122,7 +122,7 @@ def test_volume_mount_with_args():
     )
 
 
-def test_volume_mount_with_relative_paths():
+def test_bind_mount_with_relative_paths():
     with pytest.raises(
         ValueError, match="Path 'target_path' must be an absolute path."
     ):

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -92,7 +92,9 @@ def test_volume_mount_with_no_args():
     assert m.name == "role1"
     assert m.target == "target_path"
     assert m.kwargs == {"type": "volume"}
-    assert m.to_mount(vols) == docker.types.Mount("target_path", name1, type="volume")
+    assert m.to_mount(vols) == docker.types.Mount(
+        "target_path", name1, type="volume"
+    )
 
 
 def test_volume_mount_with_args():
@@ -106,7 +108,9 @@ def test_volume_mount_with_args():
     assert m.name == "role1"
     assert m.target == "target_path"
     assert m.kwargs == {"type": "volume", "read_only": True}
-    assert m.to_mount(vols) == docker.types.Mount("target_path", name1, type="volume", read_only=True)
+    assert m.to_mount(vols) == docker.types.Mount(
+        "target_path", name1, type="volume", read_only=True
+    )
 
 
 def test_bind_mount_with_no_args():
@@ -121,7 +125,9 @@ def test_bind_mount_with_no_args():
     assert m.source == "source_path"
     assert m.target == "target_path"
     assert m.kwargs == {"type": "bind"}
-    assert m.to_mount(vols) == docker.types.Mount("target_path", "source_path", type="bind")
+    assert m.to_mount(vols) == docker.types.Mount(
+        "target_path", "source_path", type="bind"
+    )
 
 
 def test_bind_mount_with_args():
@@ -135,7 +141,9 @@ def test_bind_mount_with_args():
     assert m.source == "source_path"
     assert m.target == "target_path"
     assert m.kwargs == {"type": "bind", "read_only": True}
-    assert m.to_mount(vols) == docker.types.Mount("target_path", "source_path", type="bind", read_only=True)
+    assert m.to_mount(vols) == docker.types.Mount(
+        "target_path", "source_path", type="bind", read_only=True
+    )
 
 
 def test_container_simple():


### PR DESCRIPTION
The former `ConstellationMount` was renamed `ConstellationVolumeMount` to reflect its inherent assumption that the Docker mount it wraps is a [volume mount](https://docs.docker.com/engine/storage/volumes/).

`ConstellationBindMount` is introduced, which allows constellation users to create [bind mounts](https://docs.docker.com/engine/storage/bind-mounts) that can be passed into `ConstellationContainer` by the 'mounts' parameter. `ConstellationContainer` requires/expects members of that parameter to implement a `to_mount(self, volumes)` interface.

The two `...Mount` classes are made to share a 'to_mount' interface so that 'mounts', the constructor parameter of `ConstellationContainer`, can be iterated over cleanly.

`ConstellationVolumeMount` now dictates the mount type as 'volume', reflecting its name; previously, 'volume' could have been overridden with another type via kwargs (although this would have caused an error when to_mount was called).

Version number updated as this would be a breaking change for any user who uses `ConstellationMount` - they only need to rename this import to `ConstellationVolumeMount`.