### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+on:
+  push:
+    branches: [ master ]
+    tags: [ v* ]
+  pull_request:
+    branches: [ master ]
+
+name: Publish package
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install pypa/build
+        run: |
+          python -m pip install build
+      - name: Build a binary wheel and a source tarball
+        run: |
+          python -m build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: error
+          name: python-artifacts
+          path: dist
+
+  # This assumes a PyPI Trusted Publisher has been configured for the `hipercow` package.
+  # See https://docs.pypi.org/trusted-publishers/ for more details.
+  publish-to-pypi:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    name: Publish Python distribution to PyPI
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/hipercow
+    permissions:
+      # This permission is needed for the workflow to authenticate against PyPI
+      id-token: write
+    steps:
+    - name: Download the artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: python-artifacts
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -10,3 +10,14 @@ An alternative to docker-compose more suited to our needs. A package for managin
 ```
 pip install constellation
 ```
+
+## Publishing
+
+Automatically publish to [PyPI](https://pypi.org/project/constellation).  Assuming a version number `0.1.2`:
+
+* Create a [release on github](https://github.com/reside-ic/constellation/releases/new)
+* Choose a tag -> Create a new tag: `v0.1.2`
+* Use this version as the description
+* Optionally describe the release
+* Click "Publish release"
+* This triggers the release workflow and the package will be available on PyPI in a few minutes

--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ Automatically publish to [PyPI](https://pypi.org/project/constellation).  Assumi
 * Optionally describe the release
 * Click "Publish release"
 * This triggers the release workflow and the package will be available on PyPI in a few minutes
+
+Settings are configured [here on PyPI](https://pypi.org/manage/project/constellation/settings/publishing)


### PR DESCRIPTION
Follows the pattern we use in hipercow, pyorderly and elsewhere. I've copied over the workflow (changing the branch to `master` as constellation still uses that) and added a short bit of docs. The trusted publisher configuration has been added to the PyPI project page too