### PR TITLE
Pull on missing

### DIFF
--- a/src/constellation/__about__.py
+++ b/src/constellation/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Rich FitzJohn <r.fitzjohn@imperial.ac.uk>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/src/constellation/constellation.py
+++ b/src/constellation/constellation.py
@@ -169,6 +169,7 @@ class ConstellationContainer:
         networking_config = cl.api.create_networking_config(
             {f"{network.name}": endpoint_config}
         )
+        docker_util.ensure_image(self.name, self.image)
         x_obj = cl.api.create_container(
             str(self.image),
             self.args,

--- a/src/constellation/docker_util.py
+++ b/src/constellation/docker_util.py
@@ -25,6 +25,14 @@ def ensure_volume(name):
         client.volumes.create(name)
 
 
+def ensure_image(name, image):
+    client = docker.client.from_env()
+    try:
+        client.images.get(str(image))
+    except docker.errors.NotFound:
+        image_pull(name, image)
+
+
 def exec_safely(container, args, **kwargs):
     ans = container.exec_run(args, **kwargs)
     if ans[0] != 0:

--- a/tests/test_docker_util.py
+++ b/tests/test_docker_util.py
@@ -27,6 +27,13 @@ from constellation.docker_util import (
     volume_exists,
 )
 
+def drop_image(ref):
+    client = docker.client.from_env()
+    try:
+        client.images.remove(ref)
+    except docker.errors.NotFound:
+        pass
+
 
 def test_exec_returns_output():
     cl = docker.client.from_env()
@@ -242,11 +249,7 @@ def test_pull_container():
     # docker client behaviour when pulling an image without specifying
     # a tag name is to pull *all* images, which is surprising.
     name = "hello-world:latest"
-    try:
-        client.images.remove(name)
-    except docker.errors.NotFound:
-        pass
-
+    drop_image(name)
     assert not image_exists(name)
 
     f = io.StringIO()
@@ -275,11 +278,7 @@ def test_ensure_image(capsys):
     # a tag name is to pull *all* images, which is surprising.
     name = "hello-world"
     ref = "hello-world:latest"
-    try:
-        client.images.remove(ref)
-    except docker.errors.NotFound:
-        pass
-
+    drop_image(ref)
     assert not image_exists(name)
 
     capsys.readouterr()

--- a/tests/test_docker_util.py
+++ b/tests/test_docker_util.py
@@ -29,11 +29,8 @@ from constellation.docker_util import (
 
 
 def drop_image(ref):
-    client = docker.client.from_env()
-    try:
-        client.images.remove(ref)
-    except docker.errors.NotFound:
-        pass
+    with ignoring_missing():
+        docker.client.from_env().images.remove(ref)
 
 
 def test_exec_returns_output():

--- a/tests/test_docker_util.py
+++ b/tests/test_docker_util.py
@@ -27,6 +27,7 @@ from constellation.docker_util import (
     volume_exists,
 )
 
+
 def drop_image(ref):
     client = docker.client.from_env()
     try:
@@ -244,7 +245,6 @@ def test_ensure_volume_creates_volume():
 
 
 def test_pull_container():
-    client = docker.client.from_env()
     # NOTE: you have to be careful here because the default python
     # docker client behaviour when pulling an image without specifying
     # a tag name is to pull *all* images, which is surprising.
@@ -272,7 +272,6 @@ def test_pull_container():
 
 
 def test_ensure_image(capsys):
-    client = docker.client.from_env()
     # NOTE: you have to be careful here because the default python
     # docker client behaviour when pulling an image without specifying
     # a tag name is to pull *all* images, which is surprising.


### PR DESCRIPTION
Pulls missing images rather than annoyingly failing. This used to be the behaviour until https://github.com/reside-ic/constellation/pull/22 dropped the use of `container.run()` which does this for us