### PR TITLE
Add acme-buddy support

### DIFF
--- a/src/constellation/acme.py
+++ b/src/constellation/acme.py
@@ -27,33 +27,32 @@ class AcmeBuddyConfig:
             )
 
 
-def acme_buddy_container(cfg, proxy, tls_volume):
-    name = cfg.containers["acme-buddy"]
-    dns_provider = cfg.acme_buddy.dns_provider
-
+def acme_buddy_container(
+    cfg: AcmeBuddyConfig, name: str, proxy: str, volume: str, hostname: str
+) -> constellation.ConstellationContainer:
     acme_mounts = [
-        constellation.ConstellationVolumeMount(tls_volume, "/tls"),
+        constellation.ConstellationVolumeMount(volume, "/tls"),
         constellation.ConstellationBindMount(
             "/var/run/docker.sock",
             "/var/run/docker.sock",
         ),
     ]
 
-    domain_names = ",".join((cfg.hostname, *cfg.acme_buddy.additional_domains))
+    domain_names = ",".join((hostname, *cfg.additional_domains))
 
     acme = constellation.ConstellationContainer(
         name,
-        cfg.acme_buddy.ref,
-        ports=[cfg.acme_buddy.port],
+        cfg.ref,
+        ports=[cfg.port],
         mounts=acme_mounts,
-        environment=cfg.acme_buddy.env,
+        environment=cfg.env,
         args=[
             "--domain",
             domain_names,
             "--email",
-            cfg.acme_buddy.email,
+            cfg.email,
             "--dns-provider",
-            dns_provider,
+            cfg.dns_provider,
             "--certificate-path",
             "/tls/certificate.pem",
             "--key-path",
@@ -61,7 +60,7 @@ def acme_buddy_container(cfg, proxy, tls_volume):
             "--account-path",
             "/tls/account.json",
             "--reload-container",
-            proxy.name_external(cfg.container_prefix),
+            proxy,
         ],
     )
     return acme

--- a/src/constellation/acme.py
+++ b/src/constellation/acme.py
@@ -51,6 +51,9 @@ def acme_buddy_env(dns_provider, acme_buddy_cfg):
         acme_env.update(
             {"CLOUDFLARE_DNS_API_TOKEN": acme_buddy_cfg.cloudflare_token}
         )
+    else:
+        err = f"Unrecognised DNS provider: {dns_provider}"
+        raise ValueError(err)
     return acme_env
 
 

--- a/src/constellation/acme.py
+++ b/src/constellation/acme.py
@@ -1,7 +1,12 @@
 import os
 
 import constellation
-from constellation.config import config_dict, config_integer, config_list, config_string
+from constellation.config import (
+    config_dict,
+    config_integer,
+    config_list,
+    config_string,
+)
 
 
 class AcmeBuddyConfig:

--- a/src/constellation/acme.py
+++ b/src/constellation/acme.py
@@ -1,0 +1,41 @@
+
+
+def acme_buddy_container(cfg, proxy, tls_volume):
+    name = cfg.containers["acme-buddy"]
+    acme_buddy_staging = int(os.environ.get("ACME_BUDDY_STAGING", "0"))
+    acme_env = {
+        "ACME_BUDDY_STAGING": acme_buddy_staging,
+        "HDB_ACME_USERNAME": cfg.acme_buddy_hdb_username,
+        "HDB_ACME_PASSWORD": cfg.acme_buddy_hdb_password,
+    }
+    acme_mounts = [
+        constellation.ConstellationVolumeMount(tls_volume, "/tls"),
+        constellation.ConstellationBindMount("/var/run/docker.sock", "/var/run/docker.sock"),
+    ]
+
+    domain_names = ",".join([cfg.hostname] + cfg.acme_additional_domains)
+
+    acme = constellation.ConstellationContainer(
+        name,
+        cfg.acme_buddy_ref,
+        ports=[cfg.acme_buddy_port],
+        mounts=acme_mounts,
+        environment=acme_env,
+        args=[
+            "--domain",
+            domain_names,
+            "--email",
+            cfg.acme_buddy_email,
+            "--dns-provider",
+            "hdb",
+            "--certificate-path",
+            "/tls/certificate.pem",
+            "--key-path",
+            "/tls/key.pem",
+            "--account-path",
+            "/tls/account.json",
+            "--reload-container",
+            proxy.name_external(cfg.container_prefix),
+        ],
+    )
+    return acme

--- a/src/constellation/acme.py
+++ b/src/constellation/acme.py
@@ -1,7 +1,7 @@
 import os
 
 import constellation
-from constellation.config import config_integer, config_list, config_string
+from constellation.config import config_dict, config_integer, config_list, config_string
 
 
 class AcmeBuddyConfig:
@@ -10,25 +10,11 @@ class AcmeBuddyConfig:
         repo = config_string(data, ["acme_buddy", "image", "repo"])
         tag = config_string(data, ["acme_buddy", "image", "tag"])
         self.ref = constellation.ImageReference(repo, name, tag)
-
         self.port = config_integer(data, ["acme_buddy", "port"])
         self.dns_provider = config_string(data, ["acme_buddy", "dns_provider"])
-
-        if self.dns_provider == "hdb":
-            self.hdb_username = config_string(
-                data, ["acme_buddy", "env", "HDB_ACME_USERNAME"]
-            )
-            self.hdb_password = config_string(
-                data, ["acme_buddy", "env", "HDB_ACME_PASSWORD"]
-            )
-        elif self.dns_provider == "cloudflare":
-            self.cloudflare_token = config_string(
-                data, ["acme_buddy", "env", "CLOUDFLARE_DNS_API_TOKEN"]
-            )
-        else:
-            err = f"Unrecognised DNS provider: {self.dns_provider}"
-            raise ValueError(err)
-
+        self.env = config_dict(data, ["acme_buddy", "env"])
+        if "ACME_BUDDY_STAGING" in os.environ:
+            self.env["ACME_BUDDY_STAGING"] = os.environ["ACME_BUDDY_STAGING"]
         self.email = config_string(data, ["acme_buddy", "email"])
         if "additional_domains" in data["acme_buddy"]:
             self.additional_domains = config_list(
@@ -36,31 +22,9 @@ class AcmeBuddyConfig:
             )
 
 
-def acme_buddy_env(dns_provider, acme_buddy_cfg):
-    staging = int(os.environ.get("ACME_BUDDY_STAGING", "0"))
-    acme_env = {"ACME_BUDDY_STAGING": staging}
-
-    if dns_provider == "hdb":
-        acme_env.update(
-            {
-                "HDB_ACME_USERNAME": acme_buddy_cfg.hdb_username,
-                "HDB_ACME_PASSWORD": acme_buddy_cfg.hdb_password,
-            }
-        )
-    elif dns_provider == "cloudflare":
-        acme_env.update(
-            {"CLOUDFLARE_DNS_API_TOKEN": acme_buddy_cfg.cloudflare_token}
-        )
-    else:
-        err = f"Unrecognised DNS provider: {dns_provider}"
-        raise ValueError(err)
-    return acme_env
-
-
 def acme_buddy_container(cfg, proxy, tls_volume):
     name = cfg.containers["acme-buddy"]
     dns_provider = cfg.acme_buddy.dns_provider
-    acme_env = acme_buddy_env(dns_provider, cfg.acme_buddy)
 
     acme_mounts = [
         constellation.ConstellationVolumeMount(tls_volume, "/tls"),
@@ -77,7 +41,7 @@ def acme_buddy_container(cfg, proxy, tls_volume):
         cfg.acme_buddy.ref,
         ports=[cfg.acme_buddy.port],
         mounts=acme_mounts,
-        environment=acme_env,
+        environment=cfg.acme_buddy.env,
         args=[
             "--domain",
             domain_names,

--- a/src/constellation/acme.py
+++ b/src/constellation/acme.py
@@ -10,20 +10,20 @@ from constellation.config import (
 
 
 class AcmeBuddyConfig:
-    def __init__(self, data, path):
-        name = config_string(data, [path, "image", "name"])
-        repo = config_string(data, [path, "image", "repo"])
-        tag = config_string(data, [path, "image", "tag"])
+    def __init__(self, data, path: list[str]):
+        name = config_string(data, [*path, "image", "name"])
+        repo = config_string(data, [*path, "image", "repo"])
+        tag = config_string(data, [*path, "image", "tag"])
         self.ref = constellation.ImageReference(repo, name, tag)
-        self.port = config_integer(data, [path, "port"])
-        self.dns_provider = config_string(data, [path, "dns_provider"])
-        self.env = config_dict(data, [path, "env"])
+        self.port = config_integer(data, [*path, "port"])
+        self.dns_provider = config_string(data, [*path, "dns_provider"])
+        self.env = config_dict(data, [*path, "env"])
         if "ACME_BUDDY_STAGING" in os.environ:
             self.env["ACME_BUDDY_STAGING"] = os.environ["ACME_BUDDY_STAGING"]
-        self.email = config_string(data, [path, "email"])
-        if "additional_domains" in data[path]:
+        self.email = config_string(data, [*path, "email"])
+        if "additional_domains" in config_dict(data, path):
             self.additional_domains = config_list(
-                data, [path, "additional_domains"]
+                data, [*path, "additional_domains"]
             )
 
 

--- a/src/constellation/acme.py
+++ b/src/constellation/acme.py
@@ -1,13 +1,48 @@
+from config import config_integer, config_string, config_list
+from constellation import ImageReference
+
+class AcmeConfig:
+    def __init__(self, data):
+        image_name = config.config_string(["acme_buddy", "name"])
+        image_repo = config.config_string(["acme_buddy", "repo"])
+        image_tag = config.config_string(["acme_buddy", "tag"])
+        self.acme_buddy_ref = constellation.ImageReference(repo, name, tag)
+
+        self.acme_buddy_port = config.config_integer(dat, ["acme_buddy", "port"])
+        self.acme_buddy_dns_provider = config.config_string(dat, ["acme_buddy", "dns_provider"])
+        if self.acme_buddy_dns_provider == "hdb":
+            self.acme_buddy_hdb_username = config.config_string(dat, ["acme_buddy", "env", "HDB_ACME_USERNAME"])
+            self.acme_buddy_hdb_username = config.config_string(dat, ["acme_buddy", "env", "HDB_ACME_PASSWORD"])
+        elif self.acme_buddy_dns_provider == "cloudflare":
+            self.acme_buddy_cloudflare_token = config.config_string(dat, ["acme_buddy", "env", "CLOUDFLARE_DNS_API_TOKEN"])
+        else:
+            raise ValueError(f"Unrecognised DNS provider: {self.acme_buddy_dns_provider}")
+
+        self.acme_buddy_email = config.config_string(dat, ["acme_buddy", "email"])
+        self.acme_additional_domains = config.config_list(dat, ["acme_buddy", "additional_domains"])
+
+
+def acme_buddy_env(dns_provider, cfg):
+    acme_buddy_staging = int(os.environ.get("ACME_BUDDY_STAGING", "0"))
+    acme_env = {"ACME_BUDDY_STAGING": acme_buddy_staging}
+
+    if dns_provider == "hdb":
+        acme_env.update({
+            "HDB_ACME_USERNAME": cfg.acme_buddy_hdb_username,
+            "HDB_ACME_PASSWORD": cfg.acme_buddy_hdb_password,
+        })
+    elif dns_provider == "cloudflare":
+        acme_env.update({
+            "CLOUDFLARE_DNS_API_TOKEN": cfg.acme_buddy_cloudflare_token
+        })s
+    return acme_env
 
 
 def acme_buddy_container(cfg, proxy, tls_volume):
     name = cfg.containers["acme-buddy"]
-    acme_buddy_staging = int(os.environ.get("ACME_BUDDY_STAGING", "0"))
-    acme_env = {
-        "ACME_BUDDY_STAGING": acme_buddy_staging,
-        "HDB_ACME_USERNAME": cfg.acme_buddy_hdb_username,
-        "HDB_ACME_PASSWORD": cfg.acme_buddy_hdb_password,
-    }
+    dns_provider = cfg.acme_buddy_dns_provider
+    acme_env = acme_buddy_env(dns_provider, cfg)
+
     acme_mounts = [
         constellation.ConstellationVolumeMount(tls_volume, "/tls"),
         constellation.ConstellationBindMount("/var/run/docker.sock", "/var/run/docker.sock"),
@@ -27,7 +62,7 @@ def acme_buddy_container(cfg, proxy, tls_volume):
             "--email",
             cfg.acme_buddy_email,
             "--dns-provider",
-            "hdb",
+            dns_provider,
             "--certificate-path",
             "/tls/certificate.pem",
             "--key-path",

--- a/src/constellation/acme.py
+++ b/src/constellation/acme.py
@@ -10,20 +10,20 @@ from constellation.config import (
 
 
 class AcmeBuddyConfig:
-    def __init__(self, data):
-        name = config_string(data, ["acme_buddy", "image", "name"])
-        repo = config_string(data, ["acme_buddy", "image", "repo"])
-        tag = config_string(data, ["acme_buddy", "image", "tag"])
+    def __init__(self, data, path):
+        name = config_string(data, [path, "image", "name"])
+        repo = config_string(data, [path, "image", "repo"])
+        tag = config_string(data, [path, "image", "tag"])
         self.ref = constellation.ImageReference(repo, name, tag)
-        self.port = config_integer(data, ["acme_buddy", "port"])
-        self.dns_provider = config_string(data, ["acme_buddy", "dns_provider"])
-        self.env = config_dict(data, ["acme_buddy", "env"])
+        self.port = config_integer(data, [path, "port"])
+        self.dns_provider = config_string(data, [path, "dns_provider"])
+        self.env = config_dict(data, [path, "env"])
         if "ACME_BUDDY_STAGING" in os.environ:
             self.env["ACME_BUDDY_STAGING"] = os.environ["ACME_BUDDY_STAGING"]
-        self.email = config_string(data, ["acme_buddy", "email"])
-        if "additional_domains" in data["acme_buddy"]:
+        self.email = config_string(data, [path, "email"])
+        if "additional_domains" in data[path]:
             self.additional_domains = config_list(
-                data, ["acme_buddy", "additional_domains"]
+                data, [path, "additional_domains"]
             )
 
 

--- a/src/constellation/acme.py
+++ b/src/constellation/acme.py
@@ -1,73 +1,85 @@
-from constellation.config import (
-    config_string,
-    config_integer,
-    config_list
-)
+import os
 
 import constellation
+from constellation.config import config_integer, config_list, config_string
 
-class AcmeConfig:
+
+class AcmeBuddyConfig:
     def __init__(self, data):
-        image_name = config_string(data, ["acme_buddy", "image", "name"])
-        image_repo = config_string(data, ["acme_buddy", "image", "repo"])
-        image_tag = config_string(data, ["acme_buddy", "image", "tag"])
-        self.acme_buddy_ref = constellation.ImageReference(image_repo, image_name, image_tag)
+        name = config_string(data, ["acme_buddy", "image", "name"])
+        repo = config_string(data, ["acme_buddy", "image", "repo"])
+        tag = config_string(data, ["acme_buddy", "image", "tag"])
+        self.ref = constellation.ImageReference(repo, name, tag)
 
-        self.acme_buddy_port = config_integer(data, ["acme_buddy", "port"])
-        self.acme_buddy_dns_provider = config_string(data, ["acme_buddy", "dns_provider"])
-        if self.acme_buddy_dns_provider == "hdb":
-            self.acme_buddy_hdb_username = config_string(data, ["acme_buddy", "env", "HDB_ACME_USERNAME"])
-            self.acme_buddy_hdb_password = config_string(data, ["acme_buddy", "env", "HDB_ACME_PASSWORD"])
-        elif self.acme_buddy_dns_provider == "cloudflare":
-            self.acme_buddy_cloudflare_token = config_string(data, ["acme_buddy", "env", "CLOUDFLARE_DNS_API_TOKEN"])
+        self.port = config_integer(data, ["acme_buddy", "port"])
+        self.dns_provider = config_string(data, ["acme_buddy", "dns_provider"])
+
+        if self.dns_provider == "hdb":
+            self.hdb_username = config_string(
+                data, ["acme_buddy", "env", "HDB_ACME_USERNAME"]
+            )
+            self.hdb_password = config_string(
+                data, ["acme_buddy", "env", "HDB_ACME_PASSWORD"]
+            )
+        elif self.dns_provider == "cloudflare":
+            self.cloudflare_token = config_string(
+                data, ["acme_buddy", "env", "CLOUDFLARE_DNS_API_TOKEN"]
+            )
         else:
-            raise ValueError(f"Unrecognised DNS provider: {self.acme_buddy_dns_provider}")
+            err = f"Unrecognised DNS provider: {self.dns_provider}"
+            raise ValueError(err)
 
-        self.acme_buddy_email = config_string(data, ["acme_buddy", "email"])
+        self.email = config_string(data, ["acme_buddy", "email"])
         if "additional_domains" in data["acme_buddy"]:
-            self.acme_buddy_additional_domains = config_list(data, ["acme_buddy", "additional_domains"])
+            self.additional_domains = config_list(
+                data, ["acme_buddy", "additional_domains"]
+            )
 
 
-
-def acme_buddy_env(dns_provider, cfg):
-    acme_buddy_staging = int(os.environ.get("ACME_BUDDY_STAGING", "0"))
-    acme_env = {"ACME_BUDDY_STAGING": acme_buddy_staging}
+def acme_buddy_env(dns_provider, acme_buddy_cfg):
+    staging = int(os.environ.get("ACME_BUDDY_STAGING", "0"))
+    acme_env = {"ACME_BUDDY_STAGING": staging}
 
     if dns_provider == "hdb":
-        acme_env.update({
-            "HDB_ACME_USERNAME": cfg.acme_buddy_hdb_username,
-            "HDB_ACME_PASSWORD": cfg.acme_buddy_hdb_password,
-        })
+        acme_env.update(
+            {
+                "HDB_ACME_USERNAME": acme_buddy_cfg.hdb_username,
+                "HDB_ACME_PASSWORD": acme_buddy_cfg.hdb_password,
+            }
+        )
     elif dns_provider == "cloudflare":
-        acme_env.update({
-            "CLOUDFLARE_DNS_API_TOKEN": cfg.acme_buddy_cloudflare_token
-        })
+        acme_env.update(
+            {"CLOUDFLARE_DNS_API_TOKEN": acme_buddy_cfg.cloudflare_token}
+        )
     return acme_env
 
 
 def acme_buddy_container(cfg, proxy, tls_volume):
     name = cfg.containers["acme-buddy"]
-    dns_provider = cfg.acme_buddy_dns_provider
-    acme_env = acme_buddy_env(dns_provider, cfg)
+    dns_provider = cfg.acme_buddy.dns_provider
+    acme_env = acme_buddy_env(dns_provider, cfg.acme_buddy)
 
     acme_mounts = [
         constellation.ConstellationVolumeMount(tls_volume, "/tls"),
-        constellation.ConstellationBindMount("/var/run/docker.sock", "/var/run/docker.sock"),
+        constellation.ConstellationBindMount(
+            "/var/run/docker.sock",
+            "/var/run/docker.sock",
+        ),
     ]
 
-    domain_names = ",".join([cfg.hostname] + cfg.acme_buddy_additional_domains)
+    domain_names = ",".join((cfg.hostname, *cfg.acme_buddy.additional_domains))
 
     acme = constellation.ConstellationContainer(
         name,
-        cfg.acme_buddy_ref,
-        ports=[cfg.acme_buddy_port],
+        cfg.acme_buddy.ref,
+        ports=[cfg.acme_buddy.port],
         mounts=acme_mounts,
         environment=acme_env,
         args=[
             "--domain",
             domain_names,
             "--email",
-            cfg.acme_buddy_email,
+            cfg.acme_buddy.email,
             "--dns-provider",
             dns_provider,
             "--certificate-path",

--- a/src/constellation/config.py
+++ b/src/constellation/config.py
@@ -68,6 +68,8 @@ def config_vault(data, path):
 
 
 def config_acme(data, path):
+    if isinstance(path, str):
+        path = [path]
     return acme.AcmeBuddyConfig(data, path)
 
 

--- a/src/constellation/config.py
+++ b/src/constellation/config.py
@@ -4,8 +4,7 @@ import re
 
 import yaml
 
-from constellation import vault
-from constellation import acme
+from constellation import acme, vault
 from constellation.util import ImageReference
 
 
@@ -33,7 +32,7 @@ def config_build(path, data, extra=None, options=None):
 # Utility function for centralising control over pulling information
 # out of the configuration.
 def config_value(data, path, data_type, is_optional, default=None):
-    if type(path) is str:
+    if isinstance(path, str):
         path = [path]
     for i, p in enumerate(path):
         try:
@@ -67,7 +66,8 @@ def config_vault(data, path):
     auth_args = config_dict(data, [*path, "auth", "args"], True)
     return vault.VaultConfig(url, auth_method, auth_args)
 
-def config_acme(data, path):
+
+def config_acme(data):
     return acme.AcmeConfig(data)
 
 
@@ -95,7 +95,7 @@ def config_dict_strict(data, path, keys, is_optional=False, default=None):
         msg = "Expected keys {} for {}".format(", ".join(keys), ":".join(path))
         raise ValueError(msg)
     for k, v in d.items():
-        if type(v) is not str:
+        if not isinstance(v, str):
             msg = "Expected a string for {}".format(":".join([*path, k]))
             raise ValueError(msg)
     return d
@@ -116,7 +116,7 @@ def config_enum(data, path, values, is_optional=False, default=None):
 
 
 def config_image_reference(dat, path, name="name"):
-    if type(path) is str:
+    if isinstance(path, str):
         path = [path]
     repo = config_string(dat, [*path, "repo"])
     name = config_string(dat, [*path, name])
@@ -134,7 +134,7 @@ def combine(base, extra):
     """Combine exactly two dictionaries recursively, modifying the first
     argument in place with the contets of the second"""
     for k, v in extra.items():
-        if k in base and type(base[k]) is dict and v is not None:
+        if k in base and isinstance(base[k], dict) and v is not None:
             combine(base[k], v)
         else:
             base[k] = v

--- a/src/constellation/config.py
+++ b/src/constellation/config.py
@@ -4,7 +4,7 @@ import re
 
 import yaml
 
-from constellation import acme, vault
+from constellation import vault
 from constellation.util import ImageReference
 
 
@@ -68,7 +68,9 @@ def config_vault(data, path):
 
 
 def config_acme(data):
-    return acme.AcmeConfig(data)
+    from constellation import acme
+
+    return acme.AcmeBuddyConfig(data)
 
 
 def config_string(data, path, is_optional=False, default=None):

--- a/src/constellation/config.py
+++ b/src/constellation/config.py
@@ -70,7 +70,7 @@ def config_vault(data, path):
 def config_acme(data):
     # Below: if I put this import at the top, I get a circular import
     # problem I don't know how to fix, so have to disable a warning.
-    from constellation import acme # noqa: PLC0415
+    from constellation import acme  # noqa: PLC0415
 
     return acme.AcmeBuddyConfig(data)
 

--- a/src/constellation/config.py
+++ b/src/constellation/config.py
@@ -70,7 +70,7 @@ def config_vault(data, path):
 def config_acme(data):
     # Below: if I put this import at the top, I get a circular import
     # problem I don't know how to fix, so have to disable a warning.
-    from constellation import acme  # noqa: PLC0415
+    from constellation import acme
 
     return acme.AcmeBuddyConfig(data)
 

--- a/src/constellation/config.py
+++ b/src/constellation/config.py
@@ -67,8 +67,8 @@ def config_vault(data, path):
     return vault.VaultConfig(url, auth_method, auth_args)
 
 
-def config_acme(data):
-    return acme.AcmeBuddyConfig(data)
+def config_acme(data, path):
+    return acme.AcmeBuddyConfig(data, path)
 
 
 def config_string(data, path, is_optional=False, default=None):

--- a/src/constellation/config.py
+++ b/src/constellation/config.py
@@ -69,7 +69,7 @@ def config_vault(data, path):
 
 def config_acme(data, path):
     return acme.AcmeConfig(data)
-    
+
 
 def config_string(data, path, is_optional=False, default=None):
     return config_value(data, path, "string", is_optional, default)

--- a/src/constellation/config.py
+++ b/src/constellation/config.py
@@ -68,7 +68,9 @@ def config_vault(data, path):
 
 
 def config_acme(data):
-    from constellation import acme
+    # Below: if I put this import at the top, I get a circular import
+    # problem I don't know how to fix, so have to disable a warning.
+    from constellation import acme  # noqa: PLC0415
 
     return acme.AcmeBuddyConfig(data)
 

--- a/src/constellation/config.py
+++ b/src/constellation/config.py
@@ -70,7 +70,7 @@ def config_vault(data, path):
 def config_acme(data):
     # Below: if I put this import at the top, I get a circular import
     # problem I don't know how to fix, so have to disable a warning.
-    from constellation import acme
+    from constellation import acme # noqa: PLC0415
 
     return acme.AcmeBuddyConfig(data)
 

--- a/src/constellation/config.py
+++ b/src/constellation/config.py
@@ -5,6 +5,7 @@ import re
 import yaml
 
 from constellation import vault
+from constellation import acme
 from constellation.util import ImageReference
 
 
@@ -66,6 +67,9 @@ def config_vault(data, path):
     auth_args = config_dict(data, [*path, "auth", "args"], True)
     return vault.VaultConfig(url, auth_method, auth_args)
 
+def config_acme(data, path):
+    return acme.AcmeConfig(data)
+    
 
 def config_string(data, path, is_optional=False, default=None):
     return config_value(data, path, "string", is_optional, default)

--- a/src/constellation/config.py
+++ b/src/constellation/config.py
@@ -70,7 +70,7 @@ def config_vault(data, path):
 def config_acme(data):
     # Below: if I put this import at the top, I get a circular import
     # problem I don't know how to fix, so have to disable a warning.
-    from constellation import acme  # noqa: PLC0415
+    from constellation import acme # noqa: PLC0415
 
     return acme.AcmeBuddyConfig(data)
 

--- a/src/constellation/config.py
+++ b/src/constellation/config.py
@@ -70,7 +70,7 @@ def config_vault(data, path):
 def config_acme(data):
     # Below: if I put this import at the top, I get a circular import
     # problem I don't know how to fix, so have to disable a warning.
-    from constellation import acme # noqa: PLC0415
+    from constellation import acme
 
     return acme.AcmeBuddyConfig(data)
 

--- a/src/constellation/config.py
+++ b/src/constellation/config.py
@@ -4,7 +4,7 @@ import re
 
 import yaml
 
-from constellation import vault
+from constellation import acme, vault
 from constellation.util import ImageReference
 
 
@@ -68,10 +68,6 @@ def config_vault(data, path):
 
 
 def config_acme(data):
-    # Below: if I put this import at the top, I get a circular import
-    # problem I don't know how to fix, so have to disable a warning.
-    from constellation import acme
-
     return acme.AcmeBuddyConfig(data)
 
 

--- a/src/constellation/constellation.py
+++ b/src/constellation/constellation.py
@@ -216,7 +216,7 @@ class ConstellationContainer:
                 container.remove()
 
 
-# This could be achievd by inheriting from ConstellationContainer but
+# This could be achieved by inheriting from ConstellationContainer but
 # this seems more like a has-a than an is-a relationship.
 class ConstellationService:
     def __init__(self, name, image, scale, **kwargs):

--- a/src/constellation/constellation.py
+++ b/src/constellation/constellation.py
@@ -18,16 +18,17 @@ class Constellation:
         volumes,
         data=None,
         vault_config=None,
+        acme_buddy=None,
     ):
         self.data = data
 
-        assert type(name) is str
+        assert isinstance(name, str)
         self.name = name
 
-        assert type(prefix) is str
+        assert isinstance(prefix, str)
         self.prefix = prefix
 
-        assert type(network) is str
+        assert isinstance(network, str)
         self.network = ConstellationNetwork(network)
         self.volumes = ConstellationVolumeCollection(volumes)
 
@@ -36,6 +37,7 @@ class Constellation:
 
         self.containers = ConstellationContainerCollection(containers)
         self.vault_config = vault_config
+        self.acme_buddy = acme_buddy
 
     def status(self):
         nw_name = self.network.name

--- a/src/constellation/docker_util.py
+++ b/src/constellation/docker_util.py
@@ -196,7 +196,7 @@ def string_from_container(container, path):
 
 
 def bytes_from_container(container, path):
-    stream, status = container.get_archive(path)
+    stream, _status = container.get_archive(path)
     try:
         fd, tmp = tempfile.mkstemp(text=False)
         with os.fdopen(fd, "wb") as f:

--- a/tests/test_acme.py
+++ b/tests/test_acme.py
@@ -83,7 +83,13 @@ def test_acme_buddy_container():
     proxy = types.SimpleNamespace()
     proxy.name_external = lambda prefix: f"{prefix}-proxy"
     tls_volume = "tls-volume"
-    acme = acme_buddy_container(cfg, proxy, tls_volume)
+    acme = acme_buddy_container(
+        cfg.acme_buddy,
+        cfg.containers["acme-buddy"],
+        proxy.name_external(cfg.container_prefix),
+        tls_volume,
+        cfg.hostname,
+    )
 
     assert acme.environment["ACME_BUDDY_STAGING"] == "0"
     assert acme.environment["CLOUDFLARE_DNS_API_TOKEN"] == "abcdefgh12345678"

--- a/tests/test_acme.py
+++ b/tests/test_acme.py
@@ -1,0 +1,59 @@
+from constellation.acme import (
+    AcmeConfig
+)
+
+
+def test_acme_config_hdb():
+    data = {
+        "acme_buddy": {
+            "email": "reside@imperial.ac.uk",
+            "image": {
+                "repo": "ghcr.io/reside-ic",
+                "name": "acme-buddy",
+                "tag": "main",
+            }, 
+            "port": 2112,
+            "dns_provider": "hdb",
+            "env": {
+                "HDB_ACME_USERNAME": "testuser",
+                "HDB_ACME_PASSWORD": "testpw"
+            },
+        },
+    }
+    
+    cfg = AcmeConfig(data)
+    assert cfg.acme_buddy_email == "reside@imperial.ac.uk"
+    assert cfg.acme_buddy_dns_provider == "hdb"
+    assert cfg.acme_buddy_hdb_username == "testuser"
+    assert cfg.acme_buddy_hdb_password == "testpw"
+    assert cfg.acme_buddy_ref.repo == "ghcr.io/reside-ic"
+    assert cfg.acme_buddy_ref.name == "acme-buddy"
+    assert cfg.acme_buddy_ref.tag == "main"
+    assert cfg.acme_buddy_port == 2112
+
+
+
+def test_acme_config_cloudflare():
+    data = {
+        "acme_buddy": {
+            "email": "reside@imperial.ac.uk",
+            "image": {
+                "repo": "ghcr.io/reside-ic",
+                "name": "acme-buddy",
+                "tag": "main",
+            }, 
+            "port": 2112,
+            "dns_provider": "cloudflare",
+            "env": {
+                "CLOUDFLARE_DNS_API_TOKEN": "abcdefgh12345678",
+            },
+        },
+    }
+    cfg = AcmeConfig(data)
+    assert cfg.acme_buddy_email == "reside@imperial.ac.uk"
+    assert cfg.acme_buddy_dns_provider == "cloudflare"
+    assert cfg.acme_buddy_cloudflare_token == "abcdefgh12345678"
+    assert cfg.acme_buddy_ref.repo == "ghcr.io/reside-ic"
+    assert cfg.acme_buddy_ref.name == "acme-buddy"
+    assert cfg.acme_buddy_ref.tag == "main"
+    assert cfg.acme_buddy_port == 2112

--- a/tests/test_acme.py
+++ b/tests/test_acme.py
@@ -2,7 +2,7 @@ import types
 
 import pytest
 
-from constellation.acme import acme_buddy_container, acme_buddy_env
+from constellation.acme import acme_buddy_container
 from constellation.config import config_acme
 
 
@@ -27,18 +27,16 @@ def test_acme_buddy_config_hdb():
     cfg = config_acme(data)
     assert cfg.email == "reside@imperial.ac.uk"
     assert cfg.dns_provider == "hdb"
-    assert cfg.hdb_username == "testuser"
-    assert cfg.hdb_password == "testpw"
     assert cfg.ref.repo == "ghcr.io/reside-ic"
     assert cfg.ref.name == "acme-buddy"
     assert cfg.ref.tag == "main"
     assert cfg.port == 2112
-    env = acme_buddy_env(cfg.dns_provider, cfg)
-    assert env["HDB_ACME_USERNAME"] == cfg.hdb_username
-    assert env["HDB_ACME_PASSWORD"] == cfg.hdb_password
+    assert cfg.env["HDB_ACME_USERNAME"] == "testuser"
+    assert cfg.env["HDB_ACME_PASSWORD"] == "testpw"
 
 
-def test_acme_buddy_config_cloudflare():
+def test_acme_buddy_config_cloudflare(monkeypatch):
+    monkeypatch.setenv("ACME_BUDDY_STAGING", "0")
     data = {
         "acme_buddy": {
             "additional_domains": ["anotherhost.com"],
@@ -58,57 +56,31 @@ def test_acme_buddy_config_cloudflare():
     cfg = config_acme(data)
     assert cfg.email == "reside@imperial.ac.uk"
     assert cfg.dns_provider == "cloudflare"
-    assert cfg.cloudflare_token == "abcdefgh12345678"
     assert cfg.ref.repo == "ghcr.io/reside-ic"
     assert cfg.ref.name == "acme-buddy"
     assert cfg.ref.tag == "main"
     assert cfg.port == 2112
     assert cfg.additional_domains == ["anotherhost.com"]
-    env = acme_buddy_env(cfg.dns_provider, cfg)
-    assert env["CLOUDFLARE_DNS_API_TOKEN"] == cfg.cloudflare_token
+    assert cfg.env["CLOUDFLARE_DNS_API_TOKEN"] == "abcdefgh12345678"
+    assert cfg.env["ACME_BUDDY_STAGING"] == '0'
 
 
-def test_acme_buddy_bad_provider():
-    data = {
-        "acme_buddy": {
-            "additional_domains": ["anotherhost.com"],
-            "email": "reside@imperial.ac.uk",
-            "image": {
-                "repo": "ghcr.io/reside-ic",
-                "name": "acme-buddy",
-                "tag": "main",
-            },
-            "port": 2112,
-            "dns_provider": "anotherdns",
-            "env": {
-                "ANOTHER_API_TOKEN": "abcdefgh12345678",
-            },
-        },
-    }
-    with pytest.raises(
-        ValueError, match="Unrecognised DNS provider: anotherdns"
-    ):
-        _cfg = config_acme(data)
-
-    with pytest.raises(
-        ValueError, match="Unrecognised DNS provider: anotherdns"
-    ):
-        _env = acme_buddy_env("anotherdns", data)
-
-
-def test_acme_buddy_container(monkeypatch):
-    monkeypatch.setenv("ACME_BUDDY_STAGING", "0")
+def test_acme_buddy_container():
     cfg = types.SimpleNamespace()
     cfg.containers = {"acme-buddy": "acme-buddy"}
     cfg.container_prefix = "prefix"
     cfg.hostname = "example.com"
     cfg.acme_buddy = types.SimpleNamespace(
         dns_provider="cloudflare",
-        cloudflare_token="abcdefgh12345678",
+        env={
+            "CLOUDFLARE_DNS_API_TOKEN": "abcdefgh12345678", 
+            "ACME_BUDDY_STAGING": "0",
+        },
         ref="ghcr.io/reside-ic/acme-buddy:main",
         port=2112,
         email="reside@imperial.ac.uk",
         additional_domains=["www.example.com"],
+        
     )
 
     proxy = types.SimpleNamespace()
@@ -116,7 +88,7 @@ def test_acme_buddy_container(monkeypatch):
     tls_volume = "tls-volume"
     acme = acme_buddy_container(cfg, proxy, tls_volume)
 
-    assert acme.environment["ACME_BUDDY_STAGING"] == 0
+    assert acme.environment["ACME_BUDDY_STAGING"] == '0'
     assert acme.environment["CLOUDFLARE_DNS_API_TOKEN"] == "abcdefgh12345678"
     assert acme.args[0] == "--domain"
     assert acme.args[1] == "example.com,www.example.com"

--- a/tests/test_acme.py
+++ b/tests/test_acme.py
@@ -22,7 +22,7 @@ def test_acme_buddy_config_hdb():
         },
     }
 
-    cfg = config_acme(data)
+    cfg = config_acme(data, "acme_buddy")
     assert cfg.email == "reside@imperial.ac.uk"
     assert cfg.dns_provider == "hdb"
     assert cfg.ref.repo == "ghcr.io/reside-ic"
@@ -51,7 +51,7 @@ def test_acme_buddy_config_cloudflare(monkeypatch):
             },
         },
     }
-    cfg = config_acme(data)
+    cfg = config_acme(data, "acme_buddy")
     assert cfg.email == "reside@imperial.ac.uk"
     assert cfg.dns_provider == "cloudflare"
     assert cfg.ref.repo == "ghcr.io/reside-ic"

--- a/tests/test_acme.py
+++ b/tests/test_acme.py
@@ -87,3 +87,8 @@ def test_acme_buddy_bad_provider():
         ValueError, match="Unrecognised DNS provider: anotherdns"
     ):
         _cfg = config_acme(data)
+
+    with pytest.raises(
+        ValueError, match="Unrecognised DNS provider: anotherdns"
+    ):
+        _env = acme_buddy_env("anotherdns", data)

--- a/tests/test_acme.py
+++ b/tests/test_acme.py
@@ -33,7 +33,7 @@ def test_acme_buddy_config_hdb():
 def test_acme_buddy_config_cloudflare():
     data = {
         "acme_buddy": {
-            "additional_domains": "anotherhost.com",
+            "additional_domains": ["anotherhost.com"],
             "email": "reside@imperial.ac.uk",
             "image": {
                 "repo": "ghcr.io/reside-ic",
@@ -55,4 +55,4 @@ def test_acme_buddy_config_cloudflare():
     assert cfg.ref.name == "acme-buddy"
     assert cfg.ref.tag == "main"
     assert cfg.port == 2112
-    assert cfg.additional_domains == "anotherhost.com"
+    assert cfg.additional_domains == ["anotherhost.com"]

--- a/tests/test_acme.py
+++ b/tests/test_acme.py
@@ -1,4 +1,6 @@
-from constellation.acme import AcmeBuddyConfig
+import pytest
+
+from constellation.config import config_acme
 
 
 def test_acme_buddy_config_hdb():
@@ -19,7 +21,7 @@ def test_acme_buddy_config_hdb():
         },
     }
 
-    cfg = AcmeBuddyConfig(data)
+    cfg = config_acme(data)
     assert cfg.email == "reside@imperial.ac.uk"
     assert cfg.dns_provider == "hdb"
     assert cfg.hdb_username == "testuser"
@@ -47,7 +49,7 @@ def test_acme_buddy_config_cloudflare():
             },
         },
     }
-    cfg = AcmeBuddyConfig(data)
+    cfg = config_acme(data)
     assert cfg.email == "reside@imperial.ac.uk"
     assert cfg.dns_provider == "cloudflare"
     assert cfg.cloudflare_token == "abcdefgh12345678"
@@ -56,3 +58,26 @@ def test_acme_buddy_config_cloudflare():
     assert cfg.ref.tag == "main"
     assert cfg.port == 2112
     assert cfg.additional_domains == ["anotherhost.com"]
+
+
+def test_acme_buddy_bad_provider():
+    data = {
+        "acme_buddy": {
+            "additional_domains": ["anotherhost.com"],
+            "email": "reside@imperial.ac.uk",
+            "image": {
+                "repo": "ghcr.io/reside-ic",
+                "name": "acme-buddy",
+                "tag": "main",
+            },
+            "port": 2112,
+            "dns_provider": "anotherdns",
+            "env": {
+                "ANOTHER_API_TOKEN": "abcdefgh12345678",
+            },
+        },
+    }
+    with pytest.raises(
+        ValueError, match="Unrecognised DNS provider: anotherdns"
+    ):
+        _cfg = config_acme(data)

--- a/tests/test_acme.py
+++ b/tests/test_acme.py
@@ -1,7 +1,5 @@
 import types
 
-import pytest
-
 from constellation.acme import acme_buddy_container
 from constellation.config import config_acme
 
@@ -62,7 +60,7 @@ def test_acme_buddy_config_cloudflare(monkeypatch):
     assert cfg.port == 2112
     assert cfg.additional_domains == ["anotherhost.com"]
     assert cfg.env["CLOUDFLARE_DNS_API_TOKEN"] == "abcdefgh12345678"
-    assert cfg.env["ACME_BUDDY_STAGING"] == '0'
+    assert cfg.env["ACME_BUDDY_STAGING"] == "0"
 
 
 def test_acme_buddy_container():
@@ -73,14 +71,13 @@ def test_acme_buddy_container():
     cfg.acme_buddy = types.SimpleNamespace(
         dns_provider="cloudflare",
         env={
-            "CLOUDFLARE_DNS_API_TOKEN": "abcdefgh12345678", 
+            "CLOUDFLARE_DNS_API_TOKEN": "abcdefgh12345678",
             "ACME_BUDDY_STAGING": "0",
         },
         ref="ghcr.io/reside-ic/acme-buddy:main",
         port=2112,
         email="reside@imperial.ac.uk",
         additional_domains=["www.example.com"],
-        
     )
 
     proxy = types.SimpleNamespace()
@@ -88,7 +85,7 @@ def test_acme_buddy_container():
     tls_volume = "tls-volume"
     acme = acme_buddy_container(cfg, proxy, tls_volume)
 
-    assert acme.environment["ACME_BUDDY_STAGING"] == '0'
+    assert acme.environment["ACME_BUDDY_STAGING"] == "0"
     assert acme.environment["CLOUDFLARE_DNS_API_TOKEN"] == "abcdefgh12345678"
     assert acme.args[0] == "--domain"
     assert acme.args[1] == "example.com,www.example.com"

--- a/tests/test_acme.py
+++ b/tests/test_acme.py
@@ -1,5 +1,6 @@
 import pytest
 
+from constellation.acme import acme_buddy_env
 from constellation.config import config_acme
 
 
@@ -30,6 +31,9 @@ def test_acme_buddy_config_hdb():
     assert cfg.ref.name == "acme-buddy"
     assert cfg.ref.tag == "main"
     assert cfg.port == 2112
+    env = acme_buddy_env(cfg.dns_provider, cfg)
+    assert env["HDB_ACME_USERNAME"] == cfg.hdb_username
+    assert env["HDB_ACME_PASSWORD"] == cfg.hdb_password
 
 
 def test_acme_buddy_config_cloudflare():
@@ -58,6 +62,8 @@ def test_acme_buddy_config_cloudflare():
     assert cfg.ref.tag == "main"
     assert cfg.port == 2112
     assert cfg.additional_domains == ["anotherhost.com"]
+    env = acme_buddy_env(cfg.dns_provider, cfg)
+    assert env["CLOUDFLARE_DNS_API_TOKEN"] == cfg.cloudflare_token
 
 
 def test_acme_buddy_bad_provider():

--- a/tests/test_acme.py
+++ b/tests/test_acme.py
@@ -103,11 +103,11 @@ def test_acme_buddy_container(monkeypatch):
     cfg.container_prefix = "prefix"
     cfg.hostname = "example.com"
     cfg.acme_buddy = types.SimpleNamespace(
-        dns_provider = "cloudflare",
-        cloudflare_token = "abcdefgh12345678",
-        ref = "ghcr.io/reside-ic/acme-buddy:main",
-        port = 2112,
-        email = "reside@imperial.ac.uk",
+        dns_provider="cloudflare",
+        cloudflare_token="abcdefgh12345678",
+        ref="ghcr.io/reside-ic/acme-buddy:main",
+        port=2112,
+        email="reside@imperial.ac.uk",
         additional_domains=["www.example.com"],
     )
 
@@ -125,4 +125,3 @@ def test_acme_buddy_container(monkeypatch):
     assert acme.args[4] == "--dns-provider"
     assert acme.args[5] == "cloudflare"
     assert acme.args[-1] == "prefix-proxy"
-

--- a/tests/test_acme.py
+++ b/tests/test_acme.py
@@ -1,9 +1,7 @@
-from constellation.acme import (
-    AcmeConfig
-)
+from constellation.acme import AcmeBuddyConfig
 
 
-def test_acme_config_hdb():
+def test_acme_buddy_config_hdb():
     data = {
         "acme_buddy": {
             "email": "reside@imperial.ac.uk",
@@ -11,37 +9,37 @@ def test_acme_config_hdb():
                 "repo": "ghcr.io/reside-ic",
                 "name": "acme-buddy",
                 "tag": "main",
-            }, 
+            },
             "port": 2112,
             "dns_provider": "hdb",
             "env": {
                 "HDB_ACME_USERNAME": "testuser",
-                "HDB_ACME_PASSWORD": "testpw"
+                "HDB_ACME_PASSWORD": "testpw",
             },
         },
     }
-    
-    cfg = AcmeConfig(data)
-    assert cfg.acme_buddy_email == "reside@imperial.ac.uk"
-    assert cfg.acme_buddy_dns_provider == "hdb"
-    assert cfg.acme_buddy_hdb_username == "testuser"
-    assert cfg.acme_buddy_hdb_password == "testpw"
-    assert cfg.acme_buddy_ref.repo == "ghcr.io/reside-ic"
-    assert cfg.acme_buddy_ref.name == "acme-buddy"
-    assert cfg.acme_buddy_ref.tag == "main"
-    assert cfg.acme_buddy_port == 2112
+
+    cfg = AcmeBuddyConfig(data)
+    assert cfg.email == "reside@imperial.ac.uk"
+    assert cfg.dns_provider == "hdb"
+    assert cfg.hdb_username == "testuser"
+    assert cfg.hdb_password == "testpw"
+    assert cfg.ref.repo == "ghcr.io/reside-ic"
+    assert cfg.ref.name == "acme-buddy"
+    assert cfg.ref.tag == "main"
+    assert cfg.port == 2112
 
 
-
-def test_acme_config_cloudflare():
+def test_acme_buddy_config_cloudflare():
     data = {
         "acme_buddy": {
+            "additional_domains": "anotherhost.com",
             "email": "reside@imperial.ac.uk",
             "image": {
                 "repo": "ghcr.io/reside-ic",
                 "name": "acme-buddy",
                 "tag": "main",
-            }, 
+            },
             "port": 2112,
             "dns_provider": "cloudflare",
             "env": {
@@ -49,11 +47,12 @@ def test_acme_config_cloudflare():
             },
         },
     }
-    cfg = AcmeConfig(data)
-    assert cfg.acme_buddy_email == "reside@imperial.ac.uk"
-    assert cfg.acme_buddy_dns_provider == "cloudflare"
-    assert cfg.acme_buddy_cloudflare_token == "abcdefgh12345678"
-    assert cfg.acme_buddy_ref.repo == "ghcr.io/reside-ic"
-    assert cfg.acme_buddy_ref.name == "acme-buddy"
-    assert cfg.acme_buddy_ref.tag == "main"
-    assert cfg.acme_buddy_port == 2112
+    cfg = AcmeBuddyConfig(data)
+    assert cfg.email == "reside@imperial.ac.uk"
+    assert cfg.dns_provider == "cloudflare"
+    assert cfg.cloudflare_token == "abcdefgh12345678"
+    assert cfg.ref.repo == "ghcr.io/reside-ic"
+    assert cfg.ref.name == "acme-buddy"
+    assert cfg.ref.tag == "main"
+    assert cfg.port == 2112
+    assert cfg.additional_domains == "anotherhost.com"

--- a/tests/test_acme.py
+++ b/tests/test_acme.py
@@ -98,24 +98,6 @@ def test_acme_buddy_bad_provider():
 
 def test_acme_buddy_container(monkeypatch):
     monkeypatch.setenv("ACME_BUDDY_STAGING", "0")
-    data = {
-        "acme_buddy": {
-            "additional_domains": ["anotherhost.com"],
-            "email": "reside@imperial.ac.uk",
-            "image": {
-                "repo": "ghcr.io/reside-ic",
-                "name": "acme-buddy",
-                "tag": "main",
-            },
-            "port": 2112,
-            "dns_provider": "cloudflare",
-            "env": {
-                "CLOUDFLARE_DNS_API_TOKEN": "abcdefgh12345678",
-            },
-        }
-    }
-
-    acme_cfg = config_acme(data)
     cfg = types.SimpleNamespace()
     cfg.containers = {"acme-buddy": "acme-buddy"}
     cfg.container_prefix = "prefix"

--- a/tests/test_acme.py
+++ b/tests/test_acme.py
@@ -1,6 +1,8 @@
+import types
+
 import pytest
 
-from constellation.acme import acme_buddy_env
+from constellation.acme import acme_buddy_container, acme_buddy_env
 from constellation.config import config_acme
 
 
@@ -92,3 +94,53 @@ def test_acme_buddy_bad_provider():
         ValueError, match="Unrecognised DNS provider: anotherdns"
     ):
         _env = acme_buddy_env("anotherdns", data)
+
+
+def test_acme_buddy_container(monkeypatch):
+    monkeypatch.setenv("ACME_BUDDY_STAGING", "0")
+    data = {
+        "acme_buddy": {
+            "additional_domains": ["anotherhost.com"],
+            "email": "reside@imperial.ac.uk",
+            "image": {
+                "repo": "ghcr.io/reside-ic",
+                "name": "acme-buddy",
+                "tag": "main",
+            },
+            "port": 2112,
+            "dns_provider": "cloudflare",
+            "env": {
+                "CLOUDFLARE_DNS_API_TOKEN": "abcdefgh12345678",
+            },
+        }
+    }
+
+    acme_cfg = config_acme(data)
+    cfg = types.SimpleNamespace()
+    cfg.containers = {"acme-buddy": "acme-buddy"}
+    cfg.container_prefix = "prefix"
+    cfg.hostname = "example.com"
+    cfg.acme_buddy = types.SimpleNamespace(
+        dns_provider = "cloudflare",
+        cloudflare_token = "abcdefgh12345678",
+        ref = "ghcr.io/reside-ic/acme-buddy:main",
+        port = 2112,
+        email = "reside@imperial.ac.uk",
+        additional_domains=["www.example.com"],
+    )
+
+    proxy = types.SimpleNamespace()
+    proxy.name_external = lambda prefix: f"{prefix}-proxy"
+    tls_volume = "tls-volume"
+    acme = acme_buddy_container(cfg, proxy, tls_volume)
+
+    assert acme.environment["ACME_BUDDY_STAGING"] == 0
+    assert acme.environment["CLOUDFLARE_DNS_API_TOKEN"] == "abcdefgh12345678"
+    assert acme.args[0] == "--domain"
+    assert acme.args[1] == "example.com,www.example.com"
+    assert acme.args[2] == "--email"
+    assert acme.args[3] == "reside@imperial.ac.uk"
+    assert acme.args[4] == "--dns-provider"
+    assert acme.args[5] == "cloudflare"
+    assert acme.args[-1] == "prefix-proxy"
+

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -100,7 +100,7 @@ def test_empty_volume_collection():
 
 def test_volume_mount_with_relative_paths():
     with pytest.raises(
-        ValueError, match="Path 'target_path' must be an absolute path."
+        ValueError, match=r"Path 'target_path' must be an absolute path."
     ):
         ConstellationVolumeMount("role1", "target_path")
 
@@ -142,11 +142,11 @@ def test_volume_mount_with_args():
 
 def test_bind_mount_with_relative_paths():
     with pytest.raises(
-        ValueError, match="Path 'target_path' must be an absolute path."
+        ValueError, match=r"Path 'target_path' must be an absolute path."
     ):
         ConstellationBindMount("/source_path", "target_path")
     with pytest.raises(
-        ValueError, match="Path 'source_path' must be an absolute path."
+        ValueError, match=r"Path 'source_path' must be an absolute path."
     ):
         ConstellationBindMount("source_path", "/target_path")
 

--- a/tests/test_docker_util.py
+++ b/tests/test_docker_util.py
@@ -48,7 +48,7 @@ def test_exec_safely_throws_on_failure():
     container = cl.containers.run(
         "alpine", ["sleep", "10"], detach=True, auto_remove=True
     )
-    with pytest.raises(Exception, match=""):
+    with pytest.raises(Exception, match=None):
         exec_safely(container, "missing_command")
     container.kill()
 


### PR DESCRIPTION
This PR puts the config and container creation code for acme, which we use in many places, into acme.py, so a typical deployment might look like 

https://github.com/mrc-ide/packit-deploy/pull/32

essentially calling the constellation functions
`acme_cfg = config.config_acme(dat)` and 
`acme_container = acme.acme_buddy_container(cfg, proxy, tls_volume)`

It implements also the suggestions in https://github.com/vimc/montagu-deploy/pull/22 regarding the different environment variables needed for different providers (HDB vs Cloudflare)
