### PR TITLE
Allow resolving secrets inside of a dataclass.

### DIFF
--- a/src/constellation/vault.py
+++ b/src/constellation/vault.py
@@ -1,7 +1,16 @@
 import os
 import re
+from dataclasses import is_dataclass
 
 import hvac
+
+
+# is_dataclass is weird and returns true on both the actual class and
+# instances of it.
+#
+# See https://docs.python.org/3/library/dataclasses.html#dataclasses.is_dataclass
+def is_dataclass_instance(obj):
+    return is_dataclass(obj) and not isinstance(obj, type)
 
 
 def resolve_secret(value, client):
@@ -39,8 +48,12 @@ def resolve_secrets_object(obj, client):
             updated, value = resolve_secret(v, client)
             if updated:
                 setattr(obj, k, value)
+
         if isinstance(v, dict):
             resolve_secrets_dict(v, client)
+
+        if is_dataclass(v) and not isinstance(v, type):
+            resolve_secrets_object(v, client)
 
 
 def resolve_secrets_dict(d, client):

--- a/src/constellation/vault.py
+++ b/src/constellation/vault.py
@@ -52,7 +52,7 @@ def resolve_secrets_object(obj, client):
         if isinstance(v, dict):
             resolve_secrets_dict(v, client)
 
-        if is_dataclass(v) and not isinstance(v, type):
+        if is_dataclass_instance(v):
             resolve_secrets_object(v, client)
 
 


### PR DESCRIPTION
This makes it possible to break up large configuration objects into more manageable chunks.