### PR TITLE
Allow images to be built on the fly.

### DIFF
--- a/src/constellation/__init__.py
+++ b/src/constellation/__init__.py
@@ -5,9 +5,10 @@ from constellation.constellation import (
     ConstellationService,
     ConstellationVolumeMount,
 )
-from constellation.util import ImageReference
+from constellation.util import BuildSpec, ImageReference
 
 __all__ = [
+    "BuildSpec",
     "Constellation",
     "ConstellationBindMount",
     "ConstellationContainer",

--- a/src/constellation/constellation.py
+++ b/src/constellation/constellation.py
@@ -1,11 +1,11 @@
 from abc import abstractmethod
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 import docker
 
 from constellation import docker_util, vault
-from constellation.util import BuildSpec, rand_str, tabulate
+from constellation.util import BuildSpec, ImageReference, rand_str, tabulate
 
 
 class Constellation:
@@ -116,7 +116,7 @@ class ConstellationContainer:
     def __init__(
         self,
         name,
-        image,
+        image: Union[ImageReference, BuildSpec],
         args=None,
         mounts=None,
         ports=None,
@@ -226,7 +226,9 @@ class ConstellationContainer:
 # This could be achieved by inheriting from ConstellationContainer but
 # this seems more like a has-a than an is-a relationship.
 class ConstellationService:
-    def __init__(self, name, image, scale, **kwargs):
+    def __init__(
+        self, name, image: Union[ImageReference, BuildSpec], scale, **kwargs
+    ):
         self.name = name
         self.image = image
         self.scale = scale

--- a/src/constellation/docker_util.py
+++ b/src/constellation/docker_util.py
@@ -6,6 +6,8 @@ import time
 
 import docker
 
+from constellation.util import BuildSpec
+
 
 def ensure_network(name):
     client = docker.client.from_env()
@@ -225,6 +227,14 @@ def image_pull(name, ref):
     status = "unchanged" if prev == curr else "updated"
     print(f"    `-> {curr} ({status})")
     return prev != curr
+
+
+def image_build(name: str, spec: BuildSpec):
+    client = docker.client.from_env()
+    print(f"Building docker image for {name} from {spec.path}")
+    image, _ = client.images.build(path=spec.path)
+    print(f"    `-> {image.id}")
+    return image.id
 
 
 def containers_matching(prefix, stopped):

--- a/src/constellation/util.py
+++ b/src/constellation/util.py
@@ -15,6 +15,7 @@ class ImageReference:
 
 @dataclass
 class BuildSpec:
+    # Path to the directory containing the Dockerfile
     path: str
 
 

--- a/src/constellation/util.py
+++ b/src/constellation/util.py
@@ -1,15 +1,21 @@
 import random
 import string
+from dataclasses import dataclass
 
 
+@dataclass
 class ImageReference:
-    def __init__(self, repo, name, tag):
-        self.repo = repo
-        self.name = name
-        self.tag = tag
+    repo: str
+    name: str
+    tag: str
 
     def __str__(self):
         return f"{self.repo}/{self.name}:{self.tag}"
+
+
+@dataclass
+class BuildSpec:
+    path: str
 
 
 def tabulate(x):

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -20,7 +20,7 @@ from constellation.constellation import (
     port_config,
     vault,
 )
-from constellation.util import ImageReference, rand_str
+from constellation.util import BuildSpec, ImageReference, rand_str
 
 
 def drop_image(ref):
@@ -634,5 +634,24 @@ def test_constellation_can_set_labels():
 
     assert container.get("prefix").labels == {}
     assert container_label.get("prefix").labels == labels
+
+    obj.destroy()
+
+
+def test_constellation_can_build_image(tmp_path):
+    (tmp_path / "Dockerfile").write_text(
+        """
+FROM alpine:latest
+CMD ["echo", "Hello, World"]
+"""
+    )
+
+    container = ConstellationContainer("container", BuildSpec(str(tmp_path)))
+
+    obj = Constellation("project", "prefix", [container], "network", None)
+    obj.start()
+
+    log = container.get("prefix").logs().decode("utf-8")
+    assert "Hello, World\n" == log
 
     obj.destroy()


### PR DESCRIPTION
If a `BuildSpec` is passed as the image parameter to a container, constellation will build the image using that specification before starting the container.

The image is built unconditionally. However thanks to Docker's build cache nothing happens on repeated build.